### PR TITLE
Include arm64 builds in releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,15 +57,21 @@ jobs:
         run: dotnet build src/Valet.sln
       - name: dotnet publish
         run: |
-          dotnet publish src/Valet/Valet.csproj -c Release -r win10-x64 --self-contained -o dist/win-x64 --no-restore -p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
+          dotnet publish src/Valet/Valet.csproj -c Release -r win-x64 --self-contained -o dist/win-x64 --no-restore -p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
+          dotnet publish src/Valet/Valet.csproj -c Release -r win-arm64 --self-contained -o dist/win-arm64 --no-restore -p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
           dotnet publish src/Valet/Valet.csproj -c Release -r osx-x64 --self-contained -o dist/osx-x64 --no-restore -p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
+          dotnet publish src/Valet/Valet.csproj -c Release -r osx-arm64 --self-contained -o dist/osx-arm64 --no-restore -p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
           dotnet publish src/Valet/Valet.csproj -c Release -r linux-x64 --self-contained -o dist/linux-x64 --no-restore -p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
+          dotnet publish src/Valet/Valet.csproj -c Release -r linux-arm64 --self-contained -o dist/linux-arm64 --no-restore -p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
       - name: prepare staging
         run: |
           mkdir -p ${{ runner.temp }}/staging
           cp dist/win-x64/gh-valet.exe ${{ runner.temp }}/staging/valet-windows-amd64.exe
+          cp dist/win-arm64/gh-valet.exe ${{ runner.temp }}/staging/valet-windows-arm64.exe
           cp dist/osx-x64/gh-valet ${{ runner.temp }}/staging/valet-darwin-amd64
+          cp dist/osx-arm64/gh-valet ${{ runner.temp }}/staging/valet-darwin-arm64
           cp dist/linux-x64/gh-valet ${{ runner.temp }}/staging/valet-linux-amd64
+          cp dist/linux-arm64/gh-valet ${{ runner.temp }}/staging/valet-linux-arm64
 
       - name: publish artifacts
         uses: actions/upload-artifact@v3
@@ -107,5 +113,8 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             ${{ runner.temp }}/dist/valet-windows-amd64.exe
+            ${{ runner.temp }}/dist/valet-windows-arm64.exe
             ${{ runner.temp }}/dist/valet-linux-amd64
+            ${{ runner.temp }}/dist/valet-linux-arm64
             ${{ runner.temp }}/dist/valet-darwin-amd64
+            ${{ runner.temp }}/dist/valet-darwin-arm64

--- a/src/Valet/Valet.csproj
+++ b/src/Valet/Valet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifiers>win10-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>gh-valet</AssemblyName>


### PR DESCRIPTION
## What's changing?

This updates the release to include binaries for arm64 chips.

## How's this tested?

- CI

Relates to #15 
