### PR TITLE
Add gitlab subcommand for forecast

### DIFF
--- a/src/Valet/Commands/Forecast.cs
+++ b/src/Valet/Commands/Forecast.cs
@@ -49,6 +49,7 @@ public class Forecast : BaseCommand
 
         command.AddCommand(new AzureDevOps.Forecast(_args).Command(app));
         command.AddCommand(new Jenkins.Forecast(_args).Command(app));
+        command.AddCommand(new GitLab.Forecast(_args).Command(app));
 
         return command;
     }

--- a/src/Valet/Commands/GitLab/Forecast.cs
+++ b/src/Valet/Commands/GitLab/Forecast.cs
@@ -1,0 +1,20 @@
+using System.CommandLine;
+
+namespace Valet.Commands.GitLab;
+
+public class Forecast : ContainerCommand
+{
+    public Forecast(string[] args) : base(args)
+    {
+    }
+
+    protected override string Name => "gitlab";
+    protected override string Description => "Forecasts GitHub Actions usage from historical GitLab pipeline utilization.";
+
+    protected override List<Option> Options => new()
+    {
+        Common.Namespace,
+        Common.InstanceUrl,
+        Common.AccessToken
+    };
+}


### PR DESCRIPTION
## What's changing?
This adds a jenkins subcommand for the forecast command.

## How's this tested?
```bash
dotnet run --project src/Valet/Valet.csproj -- forecast gitlab --namespace gitlab-org/quality -o tmp
```
