### PR TITLE
Make GitHub access_token instance_url optional for `migrate` command

### DIFF
--- a/src/Valet/Commands/Migrate.cs
+++ b/src/Valet/Commands/Migrate.cs
@@ -22,13 +22,13 @@ public class Migrate : BaseCommand
     private static readonly Option<string> GitHubInstanceUrl = new("--github-instance-url")
     {
         Description = "The URL of the GitHub instance.",
-        IsRequired = true
+        IsRequired = false
     };
 
     private static readonly Option<string> GitHubAccessToken = new("--github-access-token")
     {
         Description = "Access token for the GitHub repo to migrate to.",
-        IsRequired = true
+        IsRequired = false
     };
 
     protected override Command GenerateCommand(App app)


### PR DESCRIPTION
## What's changing?

This allows the `GITHUB_ACCESS_TOKEN` and `GITHUB_INSTANCE_URL` parameters to be configured with environment variables

## How's this tested?

```bash
$ GITHUB_ACCESS_TOKEN=$TOKEN dotnet run --project src/Valet/Valet.csproj -- migrate ...
```
