### PR TITLE
Fix typos for CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![.github/workflows/ci.yml](https://github.com/github/gh-valet/actions/workflows/ci.yml/badge.svg)](https://github.com/github/gh-valet/actions/workflows/ci.yml)
 
-Valet helps facilitate the migration of Azure DevOps, Circle CI, GitLab CI, Jenkins, and Travis CI pipelines to GitHub Actions. This repository provides functionality that extends the [GitHub CLI](https://cli.github.com/) to migrate pipelines to GitHub Actions using Valet.
+Valet helps facilitate the migration of Azure DevOps, CircleCI, GitLab CI, Jenkins, and Travis CI pipelines to GitHub Actions. This repository provides functionality that extends the [GitHub CLI](https://cli.github.com/) to migrate pipelines to GitHub Actions using Valet.
 
 > Because Valet is in private preview, customers must be onboarded prior to using the Valet IssueOps workflow. Please reach out to GitHub Sales to inquire about being added to the private preview.
 
@@ -13,7 +13,7 @@ Note: You can request support by creating an issue [here](https://github.com/git
 Valet currently supports migrating pipelines to GitHub Actions from the following platforms:
 
 - Azure DevOps
-- Circle CI
+- CircleCI
 - GitLab CI
 - Jenkins
 - Travis CI
@@ -92,7 +92,7 @@ Usage:
 
 Commands:
   azure-devops  An audit will output a list of data used in an Azure DevOps instance.
-  circle-ci     An audit will output a list of data used in a Circle CI instance.
+  circle-ci     An audit will output a list of data used in a CircleCI instance.
   gitlab        An audit will output a list of data used in a GitLab instance.
   jenkins       An audit will output a list of data used in a Jenkins instance.
   travis-ci     An audit will output a list of data used in a Travis CI instance.

--- a/src/Valet/Commands/Circle/Audit.cs
+++ b/src/Valet/Commands/Circle/Audit.cs
@@ -9,11 +9,11 @@ public class Audit : ContainerCommand
     }
 
     protected override string Name => "circle-ci";
-    protected override string Description => "An audit will output a list of data used in a Circle CI instance.";
+    protected override string Description => "An audit will output a list of data used in a CircleCI instance.";
 
     private static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
     {
-        Description = "The file path corresponding to the Circle CI configuration file.",
+        Description = "The file path corresponding to the CircleCI configuration file.",
         IsRequired = false,
     };
 

--- a/src/Valet/Commands/Circle/Common.cs
+++ b/src/Valet/Commands/Circle/Common.cs
@@ -6,19 +6,19 @@ public static class Common
 {
     public static readonly Option<string> InstanceUrl = new(new[] { "-u", "--circle-ci-instance-url" })
     {
-        Description = "The URL of the Circle CI instance.",
+        Description = "The URL of the CircleCI instance.",
         IsRequired = false,
     };
 
     public static readonly Option<string> AccessToken = new(new[] { "-t", "--circle-ci-access-token" })
     {
-        Description = "Access token for the Circle CI instance.",
+        Description = "Access token for the CircleCI instance.",
         IsRequired = false,
     };
 
     public static readonly Option<string> Organization = new(new[] { "-g", "--circle-ci-organization" })
     {
-        Description = "The Circle CI organization name.",
+        Description = "The CircleCI organization name.",
         IsRequired = false,
     };
 
@@ -42,13 +42,13 @@ public static class Common
 
     public static readonly Option<string> Project = new(new[] { "--circle-ci-project", "-p" })
     {
-        Description = "The Circle CI project name.",
+        Description = "The CircleCI project name.",
         IsRequired = false,
     };
 
     public static readonly Option<FileInfo> SourceFilePath = new("--source-file-path")
     {
-        Description = "The file path corresponding to the Circle CI workflow file.",
+        Description = "The file path corresponding to the CircleCI workflow file.",
         IsRequired = false,
     };
 }


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## What's changing?
Fix typos for CircleCI instead of Circle CI.

## How's this tested?
`git grep -q "Circle CI"; echo $?` should return non-0 status code:

### Example
```
$ git grep -q "Circle CI"; echo $?
1
```