### PR TITLE
Add Jenkins + GitLab to `forecast` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Usage:
 
 Commands:
   azure-devops  Forecasts GitHub Actions usage from historical Azure DevOps pipeline utilization.
+  jenkins       Forecasts GitHub Actions usage from historical Jenkins pipeline utilization.
+  gitlab        Forecasts GitHub Actions usage from historical GitLab pipeline utilization.
 ```
 
 Detailed documentation about running a forecast with Valet can be found [here](https://github.com/valet-customers/distribution/blob/main/README.md#forecast).


### PR DESCRIPTION
## What's changing?
Adds lines that mention support for Jenkins and GitLab for the `forecast` command in the README

## How's this tested?
👀

