### PR TITLE
Add CircleCI forecast subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Commands:
   azure-devops  Forecasts GitHub Actions usage from historical Azure DevOps pipeline utilization.
   jenkins       Forecasts GitHub Actions usage from historical Jenkins pipeline utilization.
   gitlab        Forecasts GitHub Actions usage from historical GitLab pipeline utilization.
+  circle-ci     Forecasts GitHub Actions usage from historical CircleCI pipeline utilization.
 ```
 
 You can find detailed information about running a forecast with Valet in the documentation that is accessible once you are enrolled in the private preview. 

--- a/src/Valet/Commands/Circle/Forecast.cs
+++ b/src/Valet/Commands/Circle/Forecast.cs
@@ -1,0 +1,25 @@
+using System.CommandLine;
+
+namespace Valet.Commands.Circle;
+
+public class Forecast : ContainerCommand
+{
+    public Forecast(string[] args) : base(args)
+    {
+    }
+
+    protected override string Name => "circle-ci";
+    protected override string Description => "Forecasts GitHub Actions usage from historical CircleCI pipeline utilization.";
+
+    protected override List<Option> Options => new()
+    {
+        Common.Organization,
+        Common.Project,
+        Common.Provider,
+        Common.InstanceUrl,
+        Common.AccessToken,
+        Common.SourceGitHubAccessToken,
+        Common.SourceGitHubInstanceUrl,
+        Common.SourceFilePath
+    };
+}

--- a/src/Valet/Commands/Circle/Forecast.cs
+++ b/src/Valet/Commands/Circle/Forecast.cs
@@ -15,7 +15,6 @@ public class Forecast : ContainerCommand
     {
         Common.Organization,
         Common.Project,
-        Common.Provider,
         Common.InstanceUrl,
         Common.AccessToken,
         Common.SourceGitHubAccessToken,

--- a/src/Valet/Commands/Forecast.cs
+++ b/src/Valet/Commands/Forecast.cs
@@ -50,6 +50,7 @@ public class Forecast : BaseCommand
         command.AddCommand(new AzureDevOps.Forecast(_args).Command(app));
         command.AddCommand(new Jenkins.Forecast(_args).Command(app));
         command.AddCommand(new GitLab.Forecast(_args).Command(app));
+        command.AddCommand(new Circle.Forecast(_args).Command(app));
 
         return command;
     }


### PR DESCRIPTION
## What's changing?
Adds the forecast subcommand for CircleCI

## How's this tested?
 Run 👇  as soon as [this](https://github.com/github/valet/pull/4216) is merged
`dotnet run --project src/Valet/Valet.csproj -- forecast circle-ci --circle-ci-organization $CIRCLE_CI_ORGANIZATION -o tmp`

Closes github/valet#4217
