### PR TITLE
[Bugfix] Docker commands hang on output

### DIFF
--- a/src/Valet/Services/ProcessService.cs
+++ b/src/Valet/Services/ProcessService.cs
@@ -80,7 +80,7 @@ public class ProcessService : IProcessService
                 while ((current = reader.Read()) >= 0)
                 {
                     Console.Write((char)current);
-                }                    
+                }
             }
         }, ctx);
     }

--- a/src/Valet/Services/ProcessService.cs
+++ b/src/Valet/Services/ProcessService.cs
@@ -69,15 +69,16 @@ public class ProcessService : IProcessService
 
     private void ReadStream(StreamReader reader, bool output, CancellationToken ctx)
     {
-        if (!output) return;
-
         Task.Run(() =>
         {
             while (!ctx.IsCancellationRequested)
             {
                 int current;
                 while ((current = reader.Read()) >= 0)
-                    Console.Write((char)current);
+                {
+                    if (output)
+                        Console.Write((char)current);
+                }                    
             }
         }, ctx);
     }

--- a/src/Valet/Services/ProcessService.cs
+++ b/src/Valet/Services/ProcessService.cs
@@ -61,16 +61,14 @@ public class ProcessService : IProcessService
         process.Exited += OnProcessExited;
         process.Start();
 
-        if (output)
-        {
-            ReadStream(process.StandardOutput, cts.Token);
-            ReadStream(process.StandardError, cts.Token);
-        }
+        
+        ReadStream(process.StandardOutput, output, cts.Token);
+        ReadStream(process.StandardError, output, cts.Token);
 
         return tcs.Task;
     }
 
-    private void ReadStream(StreamReader reader, CancellationToken ctx)
+    private void ReadStream(StreamReader reader, bool output, CancellationToken ctx)
     {
         Task.Run(() =>
         {
@@ -79,7 +77,8 @@ public class ProcessService : IProcessService
                 int current;
                 while ((current = reader.Read()) >= 0)
                 {
-                    Console.Write((char)current);
+                    if (output)
+                        Console.Write((char)current);
                 }
             }
         }, ctx);

--- a/src/Valet/Services/ProcessService.cs
+++ b/src/Valet/Services/ProcessService.cs
@@ -61,13 +61,16 @@ public class ProcessService : IProcessService
         process.Exited += OnProcessExited;
         process.Start();
 
-        ReadStream(process.StandardOutput, output, cts.Token);
-        ReadStream(process.StandardError, output, cts.Token);
+        if (output)
+        {
+            ReadStream(process.StandardOutput, cts.Token);
+            ReadStream(process.StandardError, cts.Token);
+        }
 
         return tcs.Task;
     }
 
-    private void ReadStream(StreamReader reader, bool output, CancellationToken ctx)
+    private void ReadStream(StreamReader reader, CancellationToken ctx)
     {
         Task.Run(() =>
         {
@@ -76,8 +79,7 @@ public class ProcessService : IProcessService
                 int current;
                 while ((current = reader.Read()) >= 0)
                 {
-                    if (output)
-                        Console.Write((char)current);
+                    Console.Write((char)current);
                 }                    
             }
         }, ctx);

--- a/src/Valet/Services/ProcessService.cs
+++ b/src/Valet/Services/ProcessService.cs
@@ -61,7 +61,6 @@ public class ProcessService : IProcessService
         process.Exited += OnProcessExited;
         process.Start();
 
-        
         ReadStream(process.StandardOutput, output, cts.Token);
         ReadStream(process.StandardError, output, cts.Token);
 


### PR DESCRIPTION
## What's changing?

Existing the ReadStream method early is somehow causing issues with the task cancellation.  Relocating the if(output) check to the inside of the while loop to allow all normal logic (including cancellation token) to run while still disabling output.

## How's this tested?

On a windows machine

```bash
$ dotnet run --project src/Valet/Valet.csproj -- version
```

Closes github/valet#4212
