### PR TITLE
Add Travis CI forecast subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Commands:
   jenkins       Forecasts GitHub Actions usage from historical Jenkins pipeline utilization.
   gitlab        Forecasts GitHub Actions usage from historical GitLab pipeline utilization.
   circle-ci     Forecasts GitHub Actions usage from historical CircleCI pipeline utilization.
+  travis-ci     Forecasts GitHub Actions usage from historical Travis CI pipeline utilization.
 ```
 
 You can find detailed information about running a forecast with Valet in the documentation that is accessible once you are enrolled in the private preview. 

--- a/src/Valet/Commands/Forecast.cs
+++ b/src/Valet/Commands/Forecast.cs
@@ -51,6 +51,7 @@ public class Forecast : BaseCommand
         command.AddCommand(new Jenkins.Forecast(_args).Command(app));
         command.AddCommand(new GitLab.Forecast(_args).Command(app));
         command.AddCommand(new Circle.Forecast(_args).Command(app));
+        command.AddCommand(new Travis.Forecast(_args).Command(app));
 
         return command;
     }

--- a/src/Valet/Commands/Travis/Forecast.cs
+++ b/src/Valet/Commands/Travis/Forecast.cs
@@ -16,8 +16,6 @@ public class Forecast : ContainerCommand
         Common.Organization,
         Common.InstanceUrl,
         Common.AccessToken,
-        Common.SourceGitHubInstanceUrl,
-        Common.SourceGitHubAccessToken,
         Common.SourceFilePath
     };
 }

--- a/src/Valet/Commands/Travis/Forecast.cs
+++ b/src/Valet/Commands/Travis/Forecast.cs
@@ -1,0 +1,23 @@
+using System.CommandLine;
+
+namespace Valet.Commands.Travis;
+
+public class Forecast : ContainerCommand
+{
+    public Forecast(string[] args) : base(args)
+    {
+    }
+
+    protected override string Name => "travis-ci";
+    protected override string Description => "Forecasts GitHub Actions usage from historical Travis CI pipeline utilization.";
+
+    protected override List<Option> Options => new()
+    {
+        Common.Organization,
+        Common.InstanceUrl,
+        Common.AccessToken,
+        Common.SourceGitHubInstanceUrl,
+        Common.SourceGitHubAccessToken,
+        Common.SourceFilePath
+    };
+}


### PR DESCRIPTION
## What's changing?
Adds the forecast subcommand for Travis CI

## How's this tested?
Run 👇  as soon as [this](https://github.com/github/valet/pull/4241) is merged
```bash
dotnet run --project src/Valet/Valet.csproj -- forecast travis-ci --travis-ci-organization $TRAVIS_CI_ORGANIZATION -o tmp
```

Closes https://github.com/github/valet/issues/4239
