### PR TITLE
Add `--password-stdin` option to securely provide creds

### DIFF
--- a/src/Valet.UnitTests/Services/DockerServiceTests.cs
+++ b/src/Valet.UnitTests/Services/DockerServiceTests.cs
@@ -38,7 +38,8 @@ public class DockerServiceTests
                 $"pull {server}/{image}:{version}",
                 It.IsAny<string?>(),
                 It.IsAny<IEnumerable<(string, string)>?>(),
-                It.IsAny<bool>()
+                It.IsAny<bool>(),
+                null
             )
         ).Returns(Task.CompletedTask);
 
@@ -68,10 +69,11 @@ public class DockerServiceTests
         _processService.Setup(handler =>
             handler.RunAsync(
                 "docker",
-                $"login {server} --password {password} --username {username}",
+                $"login {server} --username {username} --password-stdin",
                 It.IsAny<string?>(),
                 It.IsAny<IEnumerable<(string, string)>?>(),
-                It.IsAny<bool>()
+                It.IsAny<bool>(),
+                password
             )
         ).Returns(Task.CompletedTask);
 
@@ -101,10 +103,11 @@ public class DockerServiceTests
         _processService.Setup(handler =>
             handler.RunAsync(
                 "docker",
-                $"login {server} --password {password} --username {username}",
+                $"login {server} --username {username} --password-stdin",
                 It.IsAny<string?>(),
                 It.IsAny<IEnumerable<(string, string)>?>(),
-                It.IsAny<bool>()
+                It.IsAny<bool>(),
+                password
             )
         ).Returns(Task.CompletedTask);
 
@@ -114,7 +117,8 @@ public class DockerServiceTests
                 $"pull {server}/{image}:{version}",
                 It.IsAny<string?>(),
                 It.IsAny<IEnumerable<(string, string)>?>(),
-                It.IsAny<bool>()
+                It.IsAny<bool>(),
+                null
             )
         ).Returns(Task.CompletedTask);
 
@@ -145,7 +149,8 @@ public class DockerServiceTests
                 $"run --rm -t -v \"{Directory.GetCurrentDirectory()}\":/data {server}/{image}:{version} {string.Join(' ', arguments)}",
                 Directory.GetCurrentDirectory(),
                 new[] { new System.ValueTuple<string, string>("MSYS_NO_PATHCONV", "1") },
-                true
+                true,
+                null
             )
         ).Returns(Task.CompletedTask);
 
@@ -175,7 +180,8 @@ public class DockerServiceTests
                 $"run --rm -t --env GITHUB_ACCESS_TOKEN=foo --env GITHUB_INSTANCE_URL=https://github.fabrikam.com --env JENKINS_ACCESS_TOKEN=bar -v \"{Directory.GetCurrentDirectory()}\":/data {server}/{image}:{version} {string.Join(' ', arguments)}",
                 Directory.GetCurrentDirectory(),
                 new[] { new System.ValueTuple<string, string>("MSYS_NO_PATHCONV", "1") },
-                true
+                true,
+                null
             )
         ).Returns(Task.CompletedTask);
 
@@ -196,7 +202,8 @@ public class DockerServiceTests
                 "info",
                 It.IsAny<string?>(),
                 It.IsAny<IEnumerable<(string, string)>?>(),
-                It.IsAny<bool>()
+                It.IsAny<bool>(),
+                null
             )
         ).Returns(Task.CompletedTask);
 
@@ -214,7 +221,8 @@ public class DockerServiceTests
                 "info",
                 It.IsAny<string?>(),
                 It.IsAny<IEnumerable<(string, string)>?>(),
-                It.IsAny<bool>()
+                It.IsAny<bool>(),
+                null
             )
         ).ThrowsAsync(new Exception());
 
@@ -236,7 +244,8 @@ public class DockerServiceTests
                 $"image inspect {server}/{image}:{version}",
                 It.IsAny<string?>(),
                 It.IsAny<IEnumerable<(string, string)>?>(),
-                It.IsAny<bool>()
+                It.IsAny<bool>(),
+                null
             )
         ).Returns(Task.CompletedTask);
 
@@ -259,7 +268,8 @@ public class DockerServiceTests
                 $"image inspect {server}/{image}:{version}",
                 It.IsAny<string?>(),
                 It.IsAny<IEnumerable<(string, string)>?>(),
-                It.IsAny<bool>()
+                It.IsAny<bool>(),
+                null
             )
         ).ThrowsAsync(new Exception());
 

--- a/src/Valet/App.cs
+++ b/src/Valet/App.cs
@@ -14,7 +14,7 @@ public class App
         _dockerService = dockerService;
     }
 
-    public async Task<int> UpdateValetAsync(string? username = null, string? password = null)
+    public async Task<int> UpdateValetAsync(string? username = null, string? password = null, bool passwordStdin = false)
     {
         await _dockerService.VerifyDockerRunningAsync().ConfigureAwait(false);
 
@@ -26,7 +26,8 @@ public class App
             ValetContainerRegistry,
             "latest",
             username,
-            password
+            password,
+            passwordStdin
         );
 
         return 0;

--- a/src/Valet/Commands/Update.cs
+++ b/src/Valet/Commands/Update.cs
@@ -20,6 +20,12 @@ public class Update : BaseCommand
         Description = "Access token to authenticate with GHCR (requires read:packages scope).  Can optionally be set with GHCR_PASSWORD env variable.",
         IsRequired = false,
     };
+    
+    private static readonly Option<bool> PasswordStdInOption = new(new[] { "--password-stdin" })
+    {
+        Description = "Access token from standard input to authenticate with GHCR (requires read:packages scope).",
+        IsRequired = false,
+    };
 
     protected override Command GenerateCommand(App app)
     {
@@ -27,8 +33,9 @@ public class Update : BaseCommand
 
         command.AddOption(UsernameOption);
         command.AddOption(PasswordOption);
+        command.AddOption(PasswordStdInOption);
 
-        command.Handler = CommandHandler.Create((string? username, string? password) => app.UpdateValetAsync(username, password));
+        command.Handler = CommandHandler.Create((string? username, string? password, bool passwordStdin) => app.UpdateValetAsync(username, password, passwordStdin));
 
         return command;
     }

--- a/src/Valet/Commands/Update.cs
+++ b/src/Valet/Commands/Update.cs
@@ -20,7 +20,7 @@ public class Update : BaseCommand
         Description = "Access token to authenticate with GHCR (requires read:packages scope).  Can optionally be set with GHCR_PASSWORD env variable.",
         IsRequired = false,
     };
-    
+
     private static readonly Option<bool> PasswordStdInOption = new(new[] { "--password-stdin" })
     {
         Description = "Access token from standard input to authenticate with GHCR (requires read:packages scope).",

--- a/src/Valet/Interfaces/IDockerService.cs
+++ b/src/Valet/Interfaces/IDockerService.cs
@@ -2,7 +2,7 @@ namespace Valet.Interfaces;
 
 public interface IDockerService
 {
-    Task UpdateImageAsync(string image, string server, string version, string? username, string? password);
+    Task UpdateImageAsync(string image, string server, string version, string? username, string? password, bool passwordStdin = false);
 
     Task ExecuteCommandAsync(string image, string server, string version, params string[] arguments);
 

--- a/src/Valet/Interfaces/IProcessService.cs
+++ b/src/Valet/Interfaces/IProcessService.cs
@@ -7,6 +7,7 @@ public interface IProcessService
         string arguments,
         string? cwd = null,
         IEnumerable<(string, string)>? environmentVariables = null,
-        bool output = true
+        bool output = true,
+        string? inputStringFromStdin = null
     );
 }

--- a/src/Valet/Interfaces/IProcessService.cs
+++ b/src/Valet/Interfaces/IProcessService.cs
@@ -8,6 +8,6 @@ public interface IProcessService
         string? cwd = null,
         IEnumerable<(string, string)>? environmentVariables = null,
         bool output = true,
-        string? inputStringFromStdin = null
+        string? inputForStdIn = null
     );
 }

--- a/src/Valet/Services/DockerService.cs
+++ b/src/Valet/Services/DockerService.cs
@@ -23,18 +23,24 @@ public class DockerService : IDockerService
         _processService = processService;
     }
 
-    public async Task UpdateImageAsync(string image, string server, string version, string? username, string? password)
+    public async Task UpdateImageAsync(string image, string server, string version, string? username, string? password, bool passwordStdin = false)
     {
+        if (passwordStdin && Console.IsInputRedirected)
+        {
+            password = await Console.In.ReadToEndAsync();
+        }
+        
         if (!string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(password))
         {
             await _processService.RunAsync(
                 "docker",
-                $"login {server} --password {password} --username {username}"
+                $"login {server} --username {username} --password-stdin",
+                inputStringFromStdin: password
             ).ConfigureAwait(false);
         }
         else
         {
-            Console.WriteLine("No GHCR credentials provided.");
+            Console.WriteLine("INFO: using cached credentials because no GHCR credentials were provided.");
         }
 
         await _processService.RunAsync(
@@ -72,7 +78,7 @@ public class DockerService : IDockerService
                 output: false
             );
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             throw new Exception("Please ensure docker is installed and the docker daemon is running");
         }

--- a/src/Valet/Services/DockerService.cs
+++ b/src/Valet/Services/DockerService.cs
@@ -29,7 +29,7 @@ public class DockerService : IDockerService
         {
             password = await Console.In.ReadToEndAsync();
         }
-        
+
         if (!string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(password))
         {
             await _processService.RunAsync(
@@ -78,7 +78,7 @@ public class DockerService : IDockerService
                 output: false
             );
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             throw new Exception("Please ensure docker is installed and the docker daemon is running");
         }

--- a/src/Valet/Services/DockerService.cs
+++ b/src/Valet/Services/DockerService.cs
@@ -35,7 +35,7 @@ public class DockerService : IDockerService
             await _processService.RunAsync(
                 "docker",
                 $"login {server} --username {username} --password-stdin",
-                inputStringFromStdin: password
+                inputForStdIn: password
             ).ConfigureAwait(false);
         }
         else

--- a/src/Valet/Services/ProcessService.cs
+++ b/src/Valet/Services/ProcessService.cs
@@ -54,7 +54,7 @@ public class ProcessService : IProcessService
         ReadStream(process.StandardError, output, cts.Token);
 
         await process.WaitForExitAsync(cts.Token);
-        
+
         cts.Cancel();
         if (process.ExitCode != 0)
         {

--- a/src/Valet/Services/ProcessService.cs
+++ b/src/Valet/Services/ProcessService.cs
@@ -5,14 +5,14 @@ namespace Valet.Services;
 
 public class ProcessService : IProcessService
 {
-    public Task RunAsync(
+    public async Task RunAsync(
         string filename,
         string arguments,
         string? cwd = null,
         IEnumerable<(string, string)>? environmentVariables = null,
-        bool output = true)
+        bool output = true,
+        string? inputStringFromStdin = null)
     {
-        var tcs = new TaskCompletionSource<bool>();
         var cts = new CancellationTokenSource();
 
         var startInfo = new ProcessStartInfo
@@ -21,6 +21,7 @@ public class ProcessService : IProcessService
             Arguments = arguments,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
+            RedirectStandardInput = true,
             UseShellExecute = false,
             WorkingDirectory = cwd,
             CreateNoWindow = true
@@ -34,37 +35,32 @@ public class ProcessService : IProcessService
             }
         }
 
-        var process = new Process
+        using var process = new Process
         {
             StartInfo = startInfo,
-            EnableRaisingEvents = true,
+            EnableRaisingEvents = true
         };
-
-        void OnProcessExited(object? sender, EventArgs args)
-        {
-            process.Exited -= OnProcessExited;
-
-            cts.Cancel();
-            if (process.ExitCode == 0)
-            {
-                tcs.TrySetResult(true);
-            }
-            else
-            {
-                var error = process.StandardError.ReadToEnd();
-                tcs.TrySetException(new Exception(error));
-            }
-
-            process.Dispose();
-        }
-
-        process.Exited += OnProcessExited;
         process.Start();
+
+        if (!string.IsNullOrWhiteSpace(inputStringFromStdin))
+        {
+            var writer = process.StandardInput;
+            writer.AutoFlush = true;
+            await writer.WriteAsync(inputStringFromStdin);
+            writer.Close();
+        }
 
         ReadStream(process.StandardOutput, output, cts.Token);
         ReadStream(process.StandardError, output, cts.Token);
 
-        return tcs.Task;
+        await process.WaitForExitAsync(cts.Token);
+        
+        cts.Cancel();
+        if (process.ExitCode != 0)
+        {
+            var error = await process.StandardError.ReadToEndAsync();
+            throw new Exception(error);
+        }
     }
 
     private void ReadStream(StreamReader reader, bool output, CancellationToken ctx)

--- a/src/Valet/Services/ProcessService.cs
+++ b/src/Valet/Services/ProcessService.cs
@@ -11,7 +11,7 @@ public class ProcessService : IProcessService
         string? cwd = null,
         IEnumerable<(string, string)>? environmentVariables = null,
         bool output = true,
-        string? inputStringFromStdin = null)
+        string? inputForStdIn = null)
     {
         var cts = new CancellationTokenSource();
 
@@ -42,11 +42,11 @@ public class ProcessService : IProcessService
         };
         process.Start();
 
-        if (!string.IsNullOrWhiteSpace(inputStringFromStdin))
+        if (!string.IsNullOrWhiteSpace(inputForStdIn))
         {
             var writer = process.StandardInput;
             writer.AutoFlush = true;
-            await writer.WriteAsync(inputStringFromStdin);
+            await writer.WriteAsync(inputForStdIn);
             writer.Close();
         }
 


### PR DESCRIPTION
## What's changing?

This updates the `update` command to accept the PAT to auth with `ghcr.io` as standard input, to mirror the behavior of `docker login ...`. This has the benefit of keeping PATs away from terminal history.

## How's this tested?

Build the executable:

```bash
$ dotnet build src/Valet.sln
$ dotnet publish src/Valet/Valet.csproj -c Release -r osx-x64 --self-contained -o dist/osx-x64 --no-restore -p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
```

then pipe input to the `update` command:

```bash
$ echo $GITHUB_PAT | dist/osx-x64/gh-valet update --username $GITHUB_USERNAME --password-stdin
```

Closes #40 

cc/ @korosuke613
