### PR TITLE
Add command to configure environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Valet currently supports migrating pipelines to GitHub Actions from the followin
 - Jenkins
 - Travis CI
 
-You can find detailed information about how Valet works for each of the supported platforms in the documentation that is accessible once you are enrolled in the private preview.
+You can find detailed information about how Valet works for each of the supported platforms in the documentation that is available once you are granted access.
 
 ## Getting started with the Valet CLI
 
@@ -30,7 +30,7 @@ The following requirements must be met to be able to run Valet:
 
 - The Docker CLI must be [installed](https://docs.docker.com/get-docker/) and running
 - The official [GitHub CLI](https://cli.github.com) must be installed
-- You must have credentials to [authenticate](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry) with the GitHub Container Registry after you are enrolled in the private preview.
+- You must have credentials to [authenticate](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry) with the GitHub Container Registry after you are granted access.
 
 ### Installation
 
@@ -73,10 +73,18 @@ $ gh valet update
 **Note**: You will need to be authenticated with GitHub Container Registery for this command to be successful. Optionally, credentials can be provided to this command that will be used to authenticate on your behalf:
 
 ```bash
-$ gh valet update --username $GITHUB_HANDLE --password $GITHUB_TOKEN
+$ echo $GITHUB_TOKEN | gh valet update --username $GITHUB_HANDLE --password-stdin
 ```
 
-In order for Valet to communicate with your current CI server and GitHub, various credentials must be available for the command. These can be configured using environment variables or a `.env.local` file. You can find detailed information about using environment variables in the documentation that is accessible once you are enrolled in the private preview.
+In order for Valet to communicate with your current CI server and GitHub, various credentials must be available for the command. These can be configured using environment variables or a `.env.local` file. These environment variables can be configured in an interative prompt by running the following command:
+
+```bash
+$ gh valet configure
+? Enter value for 'GITHUB_ACCESS_TOKEN' (leave empty to skip): 
+...
+```
+
+You can find detailed information about using environment variables in the documentation that is available once you are granted access.
 
 ### Usage
 
@@ -106,7 +114,7 @@ Commands:
   travis-ci     An audit will output a list of data used in a Travis CI instance.
 ```
 
-You can find detailed information about running an audit with Valet in the documentation that is accessible once you are enrolled in the private preview. 
+You can find detailed information about running an audit with Valet in the documentation that is available once you are granted access.
 
 #### Forecast
 
@@ -132,7 +140,7 @@ Commands:
   travis-ci     Forecasts GitHub Actions usage from historical Travis CI pipeline utilization.
 ```
 
-You can find detailed information about running a forecast with Valet in the documentation that is accessible once you are enrolled in the private preview. 
+You can find detailed information about running a forecast with Valet in the documentation that is available once you are granted access.
 
 #### Dry-run
 
@@ -158,7 +166,7 @@ Commands:
   travis-ci     Convert a Travis CI pipeline to a GitHub Actions workflow and output its yaml file.
 ```
 
-You can find detailed information about running a dry-run with Valet in the documentation that is accessible once you are enrolled in the private preview. 
+You can find detailed information about running a dry-run with Valet in the documentation that is available once you are granted access.
 
 #### Migrate
 
@@ -184,4 +192,4 @@ Commands:
   travis-ci     Convert a Travis CI pipeline to a GitHub Actions workflow and and open a pull request with the changes.
 ```
 
-You can find detailed information about running a migration with Valet in the documentation that is accessible once you are enrolled in the private preview.
+You can find detailed information about running a migration with Valet in the documentation that is available once you are granted access.

--- a/src/Valet.UnitTests/Models/VariableTests.cs
+++ b/src/Valet.UnitTests/Models/VariableTests.cs
@@ -33,7 +33,7 @@ public class VariableTests
     }
 
     [TestCase("Personal access token for GitHub", null, "Personal access token for GitHub")]
-    [TestCase("Base url of the GitHub instance", "https://github.com", "Base url of the GitHub instance (default value: 'https://github.com')")]
+    [TestCase("Base url of the GitHub instance", "https://github.com", "Base url of the GitHub instance (https://github.com)")]
     public void Message_ReturnsExpected(string helpText, string? defaultValue, string expectedMessage)
     {
         // Arrange

--- a/src/Valet.UnitTests/Models/VariableTests.cs
+++ b/src/Valet.UnitTests/Models/VariableTests.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using Valet.Models;
+
+namespace Valet.UnitTests.Models;
+
+[TestFixture]
+public class VariableTests
+{
+    [TestCase(Provider.GitHub, "GitHub")]
+    [TestCase(Provider.AzureDevOps, "Azure DevOps")]
+    [TestCase(Provider.CircleCI, "CircleCI")]
+    [TestCase(Provider.GitLabCI, "GitLab CI")]
+    [TestCase(Provider.Jenkins, "Jenkins")]
+    [TestCase(Provider.TravisCI, "Travis CI")]
+    public void ProviderName_ValidName_ReturnsExpected(Provider provider, string providerName)
+    {
+        // Arrange
+        var variable = new Variable( "FOO", provider, "");
+        
+        // Act
+        Assert.AreEqual(providerName, variable.ProviderName);        
+    }
+    
+    [TestCase("USERNAME", false)]
+    [TestCase("PERSONAL_ACCESS_TOKEN", true)]
+    public void IsPassword_ReturnsExpected(string key, bool isPassword)
+    {
+        // Arrange
+        var variable = new Variable(key, Provider.GitHub, "");
+        
+        // Act
+        Assert.AreEqual(isPassword, variable.IsPassword);        
+    }
+
+    [TestCase("Personal access token for GitHub", null, "Personal access token for GitHub")]
+    [TestCase("Base url of the GitHub instance", "https://github.com", "Base url of the GitHub instance (default value: 'https://github.com')")]
+    public void Message_ReturnsExpected(string helpText, string? defaultValue, string expectedMessage)
+    {
+        // Arrange
+        var variable = new Variable("FOO", Provider.GitHub, helpText, defaultValue);
+        
+        // Act
+        Assert.AreEqual(expectedMessage, variable.Message);
+    }
+}

--- a/src/Valet.UnitTests/Models/VariableTests.cs
+++ b/src/Valet.UnitTests/Models/VariableTests.cs
@@ -15,21 +15,21 @@ public class VariableTests
     public void ProviderName_ValidName_ReturnsExpected(Provider provider, string providerName)
     {
         // Arrange
-        var variable = new Variable( "FOO", provider, "");
-        
+        var variable = new Variable("FOO", provider, "");
+
         // Act
-        Assert.AreEqual(providerName, variable.ProviderName);        
+        Assert.AreEqual(providerName, variable.ProviderName);
     }
-    
+
     [TestCase("USERNAME", false)]
     [TestCase("PERSONAL_ACCESS_TOKEN", true)]
     public void IsPassword_ReturnsExpected(string key, bool isPassword)
     {
         // Arrange
         var variable = new Variable(key, Provider.GitHub, "");
-        
+
         // Act
-        Assert.AreEqual(isPassword, variable.IsPassword);        
+        Assert.AreEqual(isPassword, variable.IsPassword);
     }
 
     [TestCase("Personal access token for GitHub", null, "Personal access token for GitHub")]
@@ -38,7 +38,7 @@ public class VariableTests
     {
         // Arrange
         var variable = new Variable("FOO", Provider.GitHub, helpText, defaultValue);
-        
+
         // Act
         Assert.AreEqual(expectedMessage, variable.Message);
     }

--- a/src/Valet.UnitTests/Services/ConfigurationServiceTests.cs
+++ b/src/Valet.UnitTests/Services/ConfigurationServiceTests.cs
@@ -31,14 +31,14 @@ public class ConfigurationServiceTests
             { "BAR", "current" },
             { "BAZ", "current" }
         };
-        
+
         var newVariables = new Dictionary<string, string>
         {
             { "FOO", "new" },
             { "BAR", "new" },
             { "BAN", "new" }
         };
-        
+
         var expectedVariables = new Dictionary<string, string>
         {
             { "FOO", "new" },
@@ -46,13 +46,13 @@ public class ConfigurationServiceTests
             { "BAZ", "current" },
             { "BAN", "new" },
         };
-        
+
         // Act
         var result = _configurationService.MergeVariables(
-            currentVariables, 
+            currentVariables,
             newVariables
             );
-        
+
         // Assert
         Assert.AreEqual(expectedVariables, result);
     }
@@ -89,10 +89,10 @@ WITH_QUOTES=""value""
             { "WITH_QUOTES", "\"value\"" },
             { "LEADING_SPACE", "value" },
         };
-        
+
         // Act
         var result = await _configurationService.ReadCurrentVariablesAsync(filePath);
-        
+
         // Assert
         Assert.AreEqual(expectedResult, result);
     }

--- a/src/Valet.UnitTests/Services/ConfigurationServiceTests.cs
+++ b/src/Valet.UnitTests/Services/ConfigurationServiceTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Valet.Interfaces;
+using Valet.Services;
+
+namespace Valet.UnitTests.Services;
+
+[TestFixture]
+public class ConfigurationServiceTests
+{
+#pragma warning disable CS8618
+    private IConfigurationService _configurationService;
+#pragma warning restore CS8618
+
+    [SetUp]
+    public void BeforeEachTest()
+    {
+        _configurationService = new ConfigurationService();
+    }
+
+    [Test]
+    public void MergeVariables_OverwritesExisting()
+    {
+        // Arrange
+        var currentVariables = new Dictionary<string, string>
+        {
+            { "FOO", "current" },
+            { "BAR", "current" },
+            { "BAZ", "current" }
+        };
+        
+        var newVariables = new Dictionary<string, string>
+        {
+            { "FOO", "new" },
+            { "BAR", "new" },
+            { "BAN", "new" }
+        };
+        
+        var expectedVariables = new Dictionary<string, string>
+        {
+            { "FOO", "new" },
+            { "BAR", "new" },
+            { "BAZ", "current" },
+            { "BAN", "new" },
+        };
+        
+        // Act
+        var result = _configurationService.MergeVariables(
+            currentVariables, 
+            newVariables
+            );
+        
+        // Assert
+        Assert.AreEqual(expectedVariables, result);
+    }
+
+    [Test]
+    public void ReadCurrentVariablesAsync_FileDoesNotExist_ThrowsAsync()
+    {
+        Assert.ThrowsAsync<FileNotFoundException>(() => _configurationService.ReadCurrentVariablesAsync("this-does-not-exist"));
+    }
+
+    [Test]
+    public async Task ReadCurrentVariablesAsync_FileExists_ReturnsVariables()
+    {
+        // Arrange
+        var filePath = Path.Combine(Path.GetTempPath(), "gh-valet.tests", ".env.local");
+        var directory = Path.GetDirectoryName(filePath)!;
+
+        var contents = @" 
+USERNAME=mona
+PASSWORD=hunter2 
+EMPTY=
+
+MALFORMED=TRUE=
+WITH_QUOTES=""value""
+  LEADING_SPACE= value
+";
+        Directory.CreateDirectory(directory);
+        await File.WriteAllTextAsync(filePath, contents);
+
+        var expectedResult = new Dictionary<string, string>
+        {
+            { "USERNAME", "mona" },
+            { "PASSWORD", "hunter2" },
+            { "WITH_QUOTES", "\"value\"" },
+            { "LEADING_SPACE", "value" },
+        };
+        
+        // Act
+        var result = await _configurationService.ReadCurrentVariablesAsync(filePath);
+        
+        // Assert
+        Assert.AreEqual(expectedResult, result);
+    }
+}

--- a/src/Valet/App.cs
+++ b/src/Valet/App.cs
@@ -8,10 +8,12 @@ public class App
     const string ValetContainerRegistry = "ghcr.io";
 
     private readonly IDockerService _dockerService;
+    private readonly IConfigurationService _configurationService;
 
-    public App(IDockerService dockerService)
+    public App(IDockerService dockerService, IConfigurationService configurationService)
     {
         _dockerService = dockerService;
+        _configurationService = configurationService;
     }
 
     public async Task<int> UpdateValetAsync(string? username = null, string? password = null, bool passwordStdin = false)
@@ -48,6 +50,17 @@ public class App
             "latest",
             args
         );
+        return 0;
+    }
+
+    public async Task<int> ConfigureAsync()
+    {
+        var currentVariables = await _configurationService.ReadCurrentVariablesAsync().ConfigureAwait(false);
+        var newVariables = await _configurationService.GetUserInputAsync().ConfigureAwait(false);
+        var mergedVariables = _configurationService.MergeVariables(currentVariables, newVariables);
+        await _configurationService.WriteVariablesAsync(mergedVariables);
+
+        Console.WriteLine("Environment variables successfully updated.");
         return 0;
     }
 }

--- a/src/Valet/App.cs
+++ b/src/Valet/App.cs
@@ -56,7 +56,7 @@ public class App
     public async Task<int> ConfigureAsync()
     {
         var currentVariables = await _configurationService.ReadCurrentVariablesAsync().ConfigureAwait(false);
-        var newVariables = await _configurationService.GetUserInputAsync().ConfigureAwait(false);
+        var newVariables = _configurationService.GetUserInput();
         var mergedVariables = _configurationService.MergeVariables(currentVariables, newVariables);
         await _configurationService.WriteVariablesAsync(mergedVariables);
 

--- a/src/Valet/Commands/Configure.cs
+++ b/src/Valet/Commands/Configure.cs
@@ -6,7 +6,7 @@ namespace Valet.Commands;
 public class Configure : BaseCommand
 {
     protected override string Name => "configure";
-    protected override string Description => "Start an interactive prompt to configure credentials used to authenticate to your CI server(s).";
+    protected override string Description => "Start an interactive prompt to configure credentials used to authenticate with your CI server(s).";
 
     protected override Command GenerateCommand(App app)
     {

--- a/src/Valet/Commands/Configure.cs
+++ b/src/Valet/Commands/Configure.cs
@@ -1,0 +1,19 @@
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+
+namespace Valet.Commands;
+
+public class Configure : BaseCommand
+{
+    protected override string Name => "configure";
+    protected override string Description => "Start an interactive prompt to configure credentials used to authenticate to your CI server(s).";
+    
+    protected override Command GenerateCommand(App app)
+    {
+        var command = base.GenerateCommand(app);
+        
+        command.Handler = CommandHandler.Create(app.ConfigureAsync);
+
+        return command;
+    }
+}

--- a/src/Valet/Commands/Configure.cs
+++ b/src/Valet/Commands/Configure.cs
@@ -7,11 +7,11 @@ public class Configure : BaseCommand
 {
     protected override string Name => "configure";
     protected override string Description => "Start an interactive prompt to configure credentials used to authenticate to your CI server(s).";
-    
+
     protected override Command GenerateCommand(App app)
     {
         var command = base.GenerateCommand(app);
-        
+
         command.Handler = CommandHandler.Create(app.ConfigureAsync);
 
         return command;

--- a/src/Valet/Constants.cs
+++ b/src/Valet/Constants.cs
@@ -4,13 +4,28 @@ public static class Constants
 {
     public static readonly List<string> UserInputVariables = new()
     {
-        "GITHUB_ACCESS_TOKEN", "GITHUB_INSTANCE_URL",
-        "AZURE_DEVOPS_ACCESS_TOKEN", "AZURE_DEVOPS_PROJECT", "AZURE_DEVOPS_ORGANIZATION", "AZURE_DEVOPS_INSTANCE_URL",
-        "CIRCLE_CI_ACCESS_TOKEN", "CIRCLE_CI_INSTANCE_URL", "CIRCLE_CI_ORGANIZATION", "CIRCLE_CI_PROVIDER",
-        "GITLAB_INSTANCE_URL", "GITLAB_ACCESS_TOKEN",
-        "JENKINSFILE_ACCESS_TOKEN", "JENKINS_USERNAME", "JENKINS_ACCESS_TOKEN", "JENKINS_INSTANCE_URL",
-        "TRAVIS_CI_ACCESS_TOKEN", "TRAVIS_CI_INSTANCE_URL", "TRAVIS_CI_SOURCE_GITHUB_ACCESS_TOKEN", "TRAVIS_CI_SOURCE_GITHUB_INSTANCE_URL", "TRAVIS_CI_ORGANIZATION"
-        
+        "GITHUB_ACCESS_TOKEN",
+        "GITHUB_INSTANCE_URL",
+        "AZURE_DEVOPS_ACCESS_TOKEN",
+        "AZURE_DEVOPS_PROJECT",
+        "AZURE_DEVOPS_ORGANIZATION",
+        "AZURE_DEVOPS_INSTANCE_URL",
+        "CIRCLE_CI_ACCESS_TOKEN",
+        "CIRCLE_CI_INSTANCE_URL",
+        "CIRCLE_CI_ORGANIZATION",
+        "CIRCLE_CI_PROVIDER",
+        "GITLAB_INSTANCE_URL",
+        "GITLAB_ACCESS_TOKEN",
+        "JENKINSFILE_ACCESS_TOKEN",
+        "JENKINS_USERNAME",
+        "JENKINS_ACCESS_TOKEN",
+        "JENKINS_INSTANCE_URL",
+        "TRAVIS_CI_ACCESS_TOKEN",
+        "TRAVIS_CI_INSTANCE_URL",
+        "TRAVIS_CI_SOURCE_GITHUB_ACCESS_TOKEN",
+        "TRAVIS_CI_SOURCE_GITHUB_INSTANCE_URL",
+        "TRAVIS_CI_ORGANIZATION"
+
     };
 
     public static Lazy<List<string>> EnvironmentVariables => new Lazy<List<string>>(() =>
@@ -20,8 +35,8 @@ public static class Constants
              "GH_ACCESS_TOKEN", "GH_INSTANCE_URL",
              "YAML_VERBOSITY", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "OCTOKIT_PROXY", "OCTOKIT_SSL_VERIFY_MODE"
          };
-         environmentVariables.AddRange(UserInputVariables);
+        environmentVariables.AddRange(UserInputVariables);
 
-         return environmentVariables;
+        return environmentVariables;
     });
 }

--- a/src/Valet/Constants.cs
+++ b/src/Valet/Constants.cs
@@ -1,42 +1,49 @@
+using Valet.Models;
+
 namespace Valet;
 
 public static class Constants
 {
-    public static readonly List<string> UserInputVariables = new()
+    private static readonly List<Variable> UserInputVariables = new()
     {
-        "GITHUB_ACCESS_TOKEN",
-        "GITHUB_INSTANCE_URL",
-        "AZURE_DEVOPS_ACCESS_TOKEN",
-        "AZURE_DEVOPS_PROJECT",
-        "AZURE_DEVOPS_ORGANIZATION",
-        "AZURE_DEVOPS_INSTANCE_URL",
-        "CIRCLE_CI_ACCESS_TOKEN",
-        "CIRCLE_CI_INSTANCE_URL",
-        "CIRCLE_CI_ORGANIZATION",
-        "CIRCLE_CI_PROVIDER",
-        "GITLAB_INSTANCE_URL",
-        "GITLAB_ACCESS_TOKEN",
-        "JENKINSFILE_ACCESS_TOKEN",
-        "JENKINS_USERNAME",
-        "JENKINS_ACCESS_TOKEN",
-        "JENKINS_INSTANCE_URL",
-        "TRAVIS_CI_ACCESS_TOKEN",
-        "TRAVIS_CI_INSTANCE_URL",
-        "TRAVIS_CI_SOURCE_GITHUB_ACCESS_TOKEN",
-        "TRAVIS_CI_SOURCE_GITHUB_INSTANCE_URL",
-        "TRAVIS_CI_ORGANIZATION"
-
+        new Variable("GITHUB_ACCESS_TOKEN", Provider.GitHub, "Personal access token for GitHub"), 
+        new Variable("GITHUB_INSTANCE_URL", Provider.GitHub, "Base url of the GitHub instance", "https://github.com"),
+        new Variable("AZURE_DEVOPS_ACCESS_TOKEN", Provider.AzureDevOps, "Personal Access Token for Azure DevOps"),
+        new Variable("AZURE_DEVOPS_INSTANCE_URL", Provider.AzureDevOps, "Base url of the Azure DevOps instance", "https://dev.azure.com"),
+        new Variable("AZURE_DEVOPS_ORGANIZATION", Provider.AzureDevOps, "Azure DevOps organization name"),
+        new Variable("AZURE_DEVOPS_PROJECT", Provider.AzureDevOps, "Azure DevOps project name"),
+        new Variable("CIRCLE_CI_ACCESS_TOKEN", Provider.CircleCI, "Personal access token for CircleCI"),
+        new Variable("CIRCLE_CI_INSTANCE_URL", Provider.CircleCI, "Base url of the CircleCI instance", "https://circleci.com"),
+        new Variable("CIRCLE_CI_ORGANIZATION", Provider.CircleCI, helpText: "Circle CI organization name"),
+        new Variable("CIRCLE_CI_SOURCE_GITHUB_ACCESS_TOKEN", Provider.CircleCI, "Personal access token to fetch source code in GitHub", "$GITHUB_ACCESS_TOKEN"),
+        new Variable("CIRCLE_CI_SOURCE_GITHUB_INSTANCE_URL", Provider.CircleCI, "Base url of the GitHub instance containing the source code", "https://github.com"),
+        new Variable("GITLAB_ACCESS_TOKEN",  Provider.GitLabCI, "Private token for GitLab"),
+        new Variable("GITLAB_INSTANCE_URL", Provider.GitLabCI, "Base url of the GitLab instance", "https://gitlab.com"),
+        new Variable("JENKINS_ACCESS_TOKEN", Provider.Jenkins, "Personal access token for Jenkins"),
+        new Variable("JENKINS_USERNAME", Provider.Jenkins, "Username of Jenkins user"),
+        new Variable("JENKINS_INSTANCE_URL", Provider.Jenkins, "Base url of the Jenkins instance"),
+        new Variable("JENKINSFILE_ACCESS_TOKEN", Provider.Jenkins, "Personal access token to fetch source code in GitHub","$GITHUB_ACCESS_TOKEN"),
+        new Variable("TRAVIS_CI_ACCESS_TOKEN", Provider.TravisCI, "Personal access token for Travis CI"),
+        new Variable("TRAVIS_CI_INSTANCE_URL", Provider.TravisCI, "Base url of the Travis CI instance", "https://travis-ci.com"),
+        new Variable("TRAVIS_CI_ORGANIZATION", Provider.TravisCI, "Travis CI organization name"),
+        new Variable("TRAVIS_CI_SOURCE_GITHUB_ACCESS_TOKEN", Provider.TravisCI, "Personal access token to fetch source code in GitHub", "$GITHUB_ACCESS_TOKEN"),
+        new Variable("TRAVIS_CI_SOURCE_GITHUB_INSTANCE_URL", Provider.TravisCI, "Base url of the GitHub instance containing the source code", "https://github.com"),
     };
 
-    public static Lazy<List<string>> EnvironmentVariables => new Lazy<List<string>>(() =>
+    public static List<string> EnvironmentVariables
     {
-        var environmentVariables = new List<string>
-         {
-             "GH_ACCESS_TOKEN", "GH_INSTANCE_URL",
-             "YAML_VERBOSITY", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "OCTOKIT_PROXY", "OCTOKIT_SSL_VERIFY_MODE"
-         };
-        environmentVariables.AddRange(UserInputVariables);
+        get {
+            var environmentVariables = new List<string>
+            {
+                "GH_ACCESS_TOKEN", "GH_INSTANCE_URL",
+                "YAML_VERBOSITY", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "OCTOKIT_PROXY", "OCTOKIT_SSL_VERIFY_MODE"
+            };
+            environmentVariables.AddRange(UserInputVariables.Select(x=> x.Key));
 
-        return environmentVariables;
-    });
+            return environmentVariables;            
+        }
+    }
+
+    public static IEnumerable<Variable> VariablesForProvider(string provider)
+        =>  UserInputVariables.Where(x => x.ProviderName == provider).ToList();
 }

--- a/src/Valet/Constants.cs
+++ b/src/Valet/Constants.cs
@@ -1,0 +1,27 @@
+namespace Valet;
+
+public static class Constants
+{
+    public static readonly List<string> UserInputVariables = new()
+    {
+        "GITHUB_ACCESS_TOKEN", "GITHUB_INSTANCE_URL",
+        "AZURE_DEVOPS_ACCESS_TOKEN", "AZURE_DEVOPS_PROJECT", "AZURE_DEVOPS_ORGANIZATION", "AZURE_DEVOPS_INSTANCE_URL",
+        "CIRCLE_CI_ACCESS_TOKEN", "CIRCLE_CI_INSTANCE_URL", "CIRCLE_CI_ORGANIZATION", "CIRCLE_CI_PROVIDER",
+        "GITLAB_INSTANCE_URL", "GITLAB_ACCESS_TOKEN",
+        "JENKINSFILE_ACCESS_TOKEN", "JENKINS_USERNAME", "JENKINS_ACCESS_TOKEN", "JENKINS_INSTANCE_URL",
+        "TRAVIS_CI_ACCESS_TOKEN", "TRAVIS_CI_INSTANCE_URL", "TRAVIS_CI_SOURCE_GITHUB_ACCESS_TOKEN", "TRAVIS_CI_SOURCE_GITHUB_INSTANCE_URL", "TRAVIS_CI_ORGANIZATION"
+        
+    };
+
+    public static Lazy<List<string>> EnvironmentVariables => new Lazy<List<string>>(() =>
+    {
+        var environmentVariables = new List<string>
+         {
+             "GH_ACCESS_TOKEN", "GH_INSTANCE_URL",
+             "YAML_VERBOSITY", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "OCTOKIT_PROXY", "OCTOKIT_SSL_VERIFY_MODE"
+         };
+         environmentVariables.AddRange(UserInputVariables);
+
+         return environmentVariables;
+    });
+}

--- a/src/Valet/Constants.cs
+++ b/src/Valet/Constants.cs
@@ -6,7 +6,7 @@ public static class Constants
 {
     private static readonly List<Variable> UserInputVariables = new()
     {
-        new Variable("GITHUB_ACCESS_TOKEN", Provider.GitHub, "Personal access token for GitHub"), 
+        new Variable("GITHUB_ACCESS_TOKEN", Provider.GitHub, "Personal access token for GitHub"),
         new Variable("GITHUB_INSTANCE_URL", Provider.GitHub, "Base url of the GitHub instance", "https://github.com"),
         new Variable("AZURE_DEVOPS_ACCESS_TOKEN", Provider.AzureDevOps, "Personal Access Token for Azure DevOps"),
         new Variable("AZURE_DEVOPS_INSTANCE_URL", Provider.AzureDevOps, "Base url of the Azure DevOps instance", "https://dev.azure.com"),
@@ -17,12 +17,12 @@ public static class Constants
         new Variable("CIRCLE_CI_ORGANIZATION", Provider.CircleCI, helpText: "Circle CI organization name"),
         new Variable("CIRCLE_CI_SOURCE_GITHUB_ACCESS_TOKEN", Provider.CircleCI, "Personal access token to fetch source code in GitHub", "$GITHUB_ACCESS_TOKEN"),
         new Variable("CIRCLE_CI_SOURCE_GITHUB_INSTANCE_URL", Provider.CircleCI, "Base url of the GitHub instance containing the source code", "https://github.com"),
-        new Variable("GITLAB_ACCESS_TOKEN",  Provider.GitLabCI, "Private token for GitLab"),
+        new Variable("GITLAB_ACCESS_TOKEN", Provider.GitLabCI, "Private token for GitLab"),
         new Variable("GITLAB_INSTANCE_URL", Provider.GitLabCI, "Base url of the GitLab instance", "https://gitlab.com"),
         new Variable("JENKINS_ACCESS_TOKEN", Provider.Jenkins, "Personal access token for Jenkins"),
         new Variable("JENKINS_USERNAME", Provider.Jenkins, "Username of Jenkins user"),
         new Variable("JENKINS_INSTANCE_URL", Provider.Jenkins, "Base url of the Jenkins instance"),
-        new Variable("JENKINSFILE_ACCESS_TOKEN", Provider.Jenkins, "Personal access token to fetch source code in GitHub","$GITHUB_ACCESS_TOKEN"),
+        new Variable("JENKINSFILE_ACCESS_TOKEN", Provider.Jenkins, "Personal access token to fetch source code in GitHub", "$GITHUB_ACCESS_TOKEN"),
         new Variable("TRAVIS_CI_ACCESS_TOKEN", Provider.TravisCI, "Personal access token for Travis CI"),
         new Variable("TRAVIS_CI_INSTANCE_URL", Provider.TravisCI, "Base url of the Travis CI instance", "https://travis-ci.com"),
         new Variable("TRAVIS_CI_ORGANIZATION", Provider.TravisCI, "Travis CI organization name"),
@@ -32,18 +32,19 @@ public static class Constants
 
     public static List<string> EnvironmentVariables
     {
-        get {
+        get
+        {
             var environmentVariables = new List<string>
             {
                 "GH_ACCESS_TOKEN", "GH_INSTANCE_URL",
                 "YAML_VERBOSITY", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "OCTOKIT_PROXY", "OCTOKIT_SSL_VERIFY_MODE"
             };
-            environmentVariables.AddRange(UserInputVariables.Select(x=> x.Key));
+            environmentVariables.AddRange(UserInputVariables.Select(x => x.Key));
 
-            return environmentVariables;            
+            return environmentVariables;
         }
     }
 
     public static IEnumerable<Variable> VariablesForProvider(string provider)
-        =>  UserInputVariables.Where(x => x.ProviderName == provider).ToList();
+        => UserInputVariables.Where(x => x.ProviderName == provider).ToList();
 }

--- a/src/Valet/Interfaces/IConfigurationService.cs
+++ b/src/Valet/Interfaces/IConfigurationService.cs
@@ -1,0 +1,18 @@
+namespace Valet.Interfaces;
+
+public interface IConfigurationService
+{
+    Task<Dictionary<string, string>> ReadCurrentVariablesAsync(string filePath = ".env.local");
+    Task<Dictionary<string, string>> GetUserInputAsync();
+    Task WriteVariablesAsync(Dictionary<string, string> variables, string filePath = ".env.local");
+    
+    Dictionary<string, string> MergeVariables(Dictionary<string, string> currentVariables, Dictionary<string, string> newVariables)
+    {
+        foreach (var variable in newVariables)
+        {
+            currentVariables[variable.Key] = variable.Value;
+        }
+        
+        return currentVariables;
+    }
+}

--- a/src/Valet/Interfaces/IConfigurationService.cs
+++ b/src/Valet/Interfaces/IConfigurationService.cs
@@ -3,7 +3,7 @@ namespace Valet.Interfaces;
 public interface IConfigurationService
 {
     Task<Dictionary<string, string>> ReadCurrentVariablesAsync(string filePath = ".env.local");
-    Task<Dictionary<string, string>> GetUserInputAsync();
+    Dictionary<string, string> GetUserInput();
     Task WriteVariablesAsync(Dictionary<string, string> variables, string filePath = ".env.local");
     
     Dictionary<string, string> MergeVariables(Dictionary<string, string> currentVariables, Dictionary<string, string> newVariables)

--- a/src/Valet/Interfaces/IConfigurationService.cs
+++ b/src/Valet/Interfaces/IConfigurationService.cs
@@ -5,14 +5,14 @@ public interface IConfigurationService
     Task<Dictionary<string, string>> ReadCurrentVariablesAsync(string filePath = ".env.local");
     Dictionary<string, string> GetUserInput();
     Task WriteVariablesAsync(Dictionary<string, string> variables, string filePath = ".env.local");
-    
+
     Dictionary<string, string> MergeVariables(Dictionary<string, string> currentVariables, Dictionary<string, string> newVariables)
     {
         foreach (var variable in newVariables)
         {
             currentVariables[variable.Key] = variable.Value;
         }
-        
+
         return currentVariables;
     }
 }

--- a/src/Valet/Models/Provider.cs
+++ b/src/Valet/Models/Provider.cs
@@ -1,0 +1,11 @@
+namespace Valet.Models;
+
+public enum Provider
+{
+    GitHub,
+    AzureDevOps,
+    CircleCI,
+    GitLabCI,
+    Jenkins,
+    TravisCI
+}

--- a/src/Valet/Models/Variable.cs
+++ b/src/Valet/Models/Variable.cs
@@ -26,7 +26,7 @@ public readonly struct Variable
     public string HelpText { get; }
     public string? DefaultValue { get; }
 
-    public string Message => DefaultValue is null ? HelpText : $"{HelpText} (default value: '{DefaultValue}')";
+    public string Message => DefaultValue is null ? HelpText : $"{HelpText} ({DefaultValue})";
 
     private Provider Provider { get; }
 }

--- a/src/Valet/Models/Variable.cs
+++ b/src/Valet/Models/Variable.cs
@@ -9,18 +9,18 @@ public readonly struct Variable
         HelpText = helpText;
         DefaultValue = defaultValue;
     }
-    
+
     public string Key { get; }
     public string ProviderName => Provider switch
-            {
-                Provider.GitHub => "GitHub",
-                Provider.AzureDevOps => "Azure DevOps",
-                Provider.CircleCI => "CircleCI",
-                Provider.GitLabCI => "GitLab CI",
-                Provider.Jenkins => "Jenkins",
-                Provider.TravisCI => "Travis CI",
-                _ => throw new ArgumentOutOfRangeException()
-            };
+    {
+        Provider.GitHub => "GitHub",
+        Provider.AzureDevOps => "Azure DevOps",
+        Provider.CircleCI => "CircleCI",
+        Provider.GitLabCI => "GitLab CI",
+        Provider.Jenkins => "Jenkins",
+        Provider.TravisCI => "Travis CI",
+        _ => throw new ArgumentOutOfRangeException()
+    };
 
     public bool IsPassword => Key.EndsWith("ACCESS_TOKEN");
     public string HelpText { get; }

--- a/src/Valet/Models/Variable.cs
+++ b/src/Valet/Models/Variable.cs
@@ -1,0 +1,32 @@
+namespace Valet.Models;
+
+public readonly struct Variable
+{
+    public Variable(string key, Provider provider, string helpText, string? defaultValue = null)
+    {
+        Key = key;
+        Provider = provider;
+        HelpText = helpText;
+        DefaultValue = defaultValue;
+    }
+    
+    public string Key { get; }
+    public string ProviderName => Provider switch
+            {
+                Provider.GitHub => "GitHub",
+                Provider.AzureDevOps => "Azure DevOps",
+                Provider.CircleCI => "CircleCI",
+                Provider.GitLabCI => "GitLab CI",
+                Provider.Jenkins => "Jenkins",
+                Provider.TravisCI => "Travis CI",
+                _ => throw new ArgumentOutOfRangeException()
+            };
+
+    public bool IsPassword => Key.EndsWith("ACCESS_TOKEN");
+    public string HelpText { get; }
+    public string? DefaultValue { get; }
+
+    public string Message => DefaultValue is null ? HelpText : $"{HelpText} (default value: '{DefaultValue}')";
+
+    private Provider Provider { get; }
+}

--- a/src/Valet/Program.cs
+++ b/src/Valet/Program.cs
@@ -8,13 +8,15 @@ using Valet.Services;
 var processService = new ProcessService();
 
 var app = new App(
-    new DockerService(processService)
+    new DockerService(processService),
+    new ConfigurationService()
 );
 
 var command = new RootCommand("Valet is a tool that facilitates migrations to GitHub Actions.")
 {
     new Update().Command(app),
     new Valet.Commands.Version(args).Command(app),
+    new Configure().Command(app),
     new Audit(args).Command(app),
     new DryRun(args).Command(app),
     new Migrate(args).Command(app),

--- a/src/Valet/Services/ConfigurationService.cs
+++ b/src/Valet/Services/ConfigurationService.cs
@@ -28,7 +28,7 @@ public class ConfigurationService : IConfigurationService
     {
         var providers = Prompt.MultiSelect(
             "Which CI providers are you configuring?",
-            new[] { "Azure DevOps", "CircleCI", "GitLab CI", "Jenkins", "Travis CI" }, 
+            new[] { "Azure DevOps", "CircleCI", "GitLab CI", "Jenkins", "Travis CI" },
             pageSize: 5
         );
 

--- a/src/Valet/Services/ConfigurationService.cs
+++ b/src/Valet/Services/ConfigurationService.cs
@@ -1,0 +1,50 @@
+using System.Text;
+using Valet.Interfaces;
+
+namespace Valet.Services;
+
+public class ConfigurationService : IConfigurationService
+{
+    public async Task<Dictionary<string, string>> ReadCurrentVariablesAsync(string filePath = ".env.local")
+    {
+        var lines = await File.ReadAllLinesAsync(filePath);
+
+        var variables = new Dictionary<string, string>();
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            var variable = line.Split('=', StringSplitOptions.TrimEntries);
+            if (variable.Length != 2) continue;
+
+            variables[variable[0]] = variable[1];
+        }
+
+        return variables;
+    }
+
+    public async Task<Dictionary<string, string>> GetUserInputAsync()
+    {
+        var input = new Dictionary<string, string>();
+
+        foreach (var variable in Constants.UserInputVariables)
+        {
+            Console.Write($"Enter value for '{variable}' (leave empty to omit): ");
+            var value = await Console.In.ReadLineAsync();
+            if (string.IsNullOrWhiteSpace(value)) continue;
+            
+            input[variable] = value;
+        }
+
+        return input;
+    }
+
+    public async Task WriteVariablesAsync(Dictionary<string, string> variables, string filePath = ".env.local")
+    {
+        var lines = variables.Select(kvp => $"{kvp.Key}={kvp.Value}").ToList();
+
+        Console.WriteLine(string.Join('\n', lines));
+        await Task.FromResult(true);
+        // await File.WriteAllLinesAsync(filePath, lines);
+    }
+}

--- a/src/Valet/Services/ConfigurationService.cs
+++ b/src/Valet/Services/ConfigurationService.cs
@@ -27,15 +27,15 @@ public class ConfigurationService : IConfigurationService
     public Dictionary<string, string> GetUserInput()
     {
         var input = new Dictionary<string, string>();
-        
+
         foreach (var variable in Constants.UserInputVariables)
         {
-            var value = variable.EndsWith("TOKEN") 
-                ? Prompt.Password($"Enter value for '{variable}' (leave empty to skip)") 
+            var value = variable.EndsWith("TOKEN")
+                ? Prompt.Password($"Enter value for '{variable}' (leave empty to skip)")
                 : Prompt.Input<string>($"Enter value for '{variable}' (leave empty to skip)");
-            
+
             if (string.IsNullOrWhiteSpace(value)) continue;
-            
+
             input[variable] = value;
         }
 

--- a/src/Valet/Services/ConfigurationService.cs
+++ b/src/Valet/Services/ConfigurationService.cs
@@ -34,6 +34,8 @@ public class ConfigurationService : IConfigurationService
 
         var input = new Dictionary<string, string>();
 
+        Console.WriteLine("Enter the following values (leave empty to omit):");
+
         foreach (var provider in providers.Prepend("GitHub"))
         {
             if (string.IsNullOrWhiteSpace(provider)) continue;

--- a/src/Valet/Services/DockerService.cs
+++ b/src/Valet/Services/DockerService.cs
@@ -96,7 +96,7 @@ public class DockerService : IDockerService
             yield return "--env-file .env.local";
         }
 
-        foreach (var env in Constants.EnvironmentVariables.Value)
+        foreach (var env in Constants.EnvironmentVariables)
         {
             var value = Environment.GetEnvironmentVariable(env);
 

--- a/src/Valet/Services/DockerService.cs
+++ b/src/Valet/Services/DockerService.cs
@@ -7,17 +7,6 @@ public class DockerService : IDockerService
 {
     private readonly IProcessService _processService;
 
-    private readonly string[] _valetEnvVars =
-    {
-        "GH_ACCESS_TOKEN", "GH_INSTANCE_URL", "GITHUB_ACCESS_TOKEN", "GITHUB_INSTANCE_URL",
-        "JENKINSFILE_ACCESS_TOKEN", "JENKINS_USERNAME", "JENKINS_ACCESS_TOKEN", "JENKINS_INSTANCE_URL",
-        "TRAVIS_CI_ACCESS_TOKEN", "TRAVIS_CI_INSTANCE_URL", "TRAVIS_CI_SOURCE_GITHUB_ACCESS_TOKEN", "TRAVIS_CI_SOURCE_GITHUB_INSTANCE_URL", "TRAVIS_CI_ORGANIZATION",
-        "CIRCLE_CI_ACCESS_TOKEN", "CIRCLE_CI_INSTANCE_URL", "CIRCLE_CI_ORGANIZATION", "CIRCLE_CI_PROVIDER",
-        "GITLAB_INSTANCE_URL", "GITLAB_ACCESS_TOKEN",
-        "AZURE_DEVOPS_ACCESS_TOKEN", "AZURE_DEVOPS_PROJECT", "AZURE_DEVOPS_ORGANIZATION", "AZURE_DEVOPS_INSTANCE_URL",
-        "YAML_VERBOSITY", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "OCTOKIT_PROXY", "OCTOKIT_SSL_VERIFY_MODE",
-    };
-
     public DockerService(IProcessService processService)
     {
         _processService = processService;
@@ -107,7 +96,7 @@ public class DockerService : IDockerService
             yield return "--env-file .env.local";
         }
 
-        foreach (var env in _valetEnvVars)
+        foreach (var env in Constants.EnvironmentVariables.Value)
         {
             var value = Environment.GetEnvironmentVariable(env);
 

--- a/src/Valet/Valet.csproj
+++ b/src/Valet/Valet.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Sharprompt" Version="2.4.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>


### PR DESCRIPTION
## What's changing?

This introduces a `configure` command to the CLI that is an interactive prompt to set a user's `.env.local` file. This command will only write new entries to the `.env.local` file if a value was provided in the interactive prompt. This is so that the command can be run multiple times and entries from previous runs will be preserved unless a new value was provided.

## How's this tested?

- Specs

```bash
$ dotnet run --project src/Valet/Valet.csproj -- configure
```

Closes github/valet#4090
