### PR TITLE
Update `version` command to output additional information

### DIFF
--- a/.github/ISSUE_TEMPLATE/support.yml
+++ b/.github/ISSUE_TEMPLATE/support.yml
@@ -18,23 +18,9 @@ body:
         - label: macOS
         - label: Windows
   - type: textarea
-    id: gh-version
-    attributes:
-      label: What version of the `gh` CLI are you using?
-      placeholder: i.e. the output of `gh version`
-    validations:
-      required: true
-  - type: textarea
-    id: gh-valet-version
-    attributes:
-      label: What version of the `gh-valet` extension are you using?
-      placeholder: i.e. the output of `gh extension list | grep valet`
-    validations:
-      required: true
-  - type: textarea
     id: valet-version
     attributes:
-      label: What version of the `valet` docker container are you using?
+      label: What version of the tool are you using?
       placeholder: i.e. the output of `gh valet version`
     validations:
       required: true

--- a/src/Valet/App.cs
+++ b/src/Valet/App.cs
@@ -8,10 +8,12 @@ public class App
     const string ValetContainerRegistry = "ghcr.io";
 
     private readonly IDockerService _dockerService;
-
-    public App(IDockerService dockerService)
+    private readonly IProcessService _processService;
+    
+    public App(IDockerService dockerService, IProcessService processService)
     {
         _dockerService = dockerService;
+        _processService = processService;
     }
 
     public async Task<int> UpdateValetAsync(string? username = null, string? password = null, bool passwordStdin = false)
@@ -48,6 +50,24 @@ public class App
             "latest",
             args
         );
+        return 0;
+    }
+
+    public async Task<int> GetVersionAsync()
+    {
+        var ghVersion = await _processService.RunAndCaptureAsync("gh", "version");
+        var ghValetVersion = await _processService.RunAndCaptureAsync("gh", "extension list");
+        var valetVersion = await _processService.RunAndCaptureAsync("docker", $"run --rm {ValetContainerRegistry}/{ValetImage}:latest version", throwOnError:false);
+
+        var formattedGhVersion = ghVersion.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault();
+        var formattedGhValetVersion = ghValetVersion.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault(x => x.Contains("github/gh-valet"));
+        var formattedValetVersion = valetVersion.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault() ?? "unknown";
+
+        Console.WriteLine(formattedGhVersion);
+        Console.WriteLine(formattedGhValetVersion);
+        Console.WriteLine($"valet-cli\t{formattedValetVersion}");
+
         return 0;
     }
 }

--- a/src/Valet/App.cs
+++ b/src/Valet/App.cs
@@ -69,6 +69,8 @@ public class App
         Console.WriteLine(formattedGhVersion);
         Console.WriteLine(formattedGhValetVersion);
         Console.WriteLine($"valet-cli\t{formattedValetVersion}");
+
+        return 0;
     }
 
     public async Task<int> ConfigureAsync()

--- a/src/Valet/App.cs
+++ b/src/Valet/App.cs
@@ -9,7 +9,7 @@ public class App
 
     private readonly IDockerService _dockerService;
     private readonly IProcessService _processService;
-    
+
     public App(IDockerService dockerService, IProcessService processService)
     {
         _dockerService = dockerService;
@@ -57,7 +57,7 @@ public class App
     {
         var ghVersion = await _processService.RunAndCaptureAsync("gh", "version");
         var ghValetVersion = await _processService.RunAndCaptureAsync("gh", "extension list");
-        var valetVersion = await _processService.RunAndCaptureAsync("docker", $"run --rm {ValetContainerRegistry}/{ValetImage}:latest version", throwOnError:false);
+        var valetVersion = await _processService.RunAndCaptureAsync("docker", $"run --rm {ValetContainerRegistry}/{ValetImage}:latest version", throwOnError: false);
 
         var formattedGhVersion = ghVersion.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault();
         var formattedGhValetVersion = ghValetVersion.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)

--- a/src/Valet/Commands/Version.cs
+++ b/src/Valet/Commands/Version.cs
@@ -11,7 +11,7 @@ public class Version : BaseCommand
     protected override Command GenerateCommand(App app)
     {
         var command = base.GenerateCommand(app);
-        
+
         command.Handler = CommandHandler.Create(app.GetVersionAsync);
 
         return command;

--- a/src/Valet/Commands/Version.cs
+++ b/src/Valet/Commands/Version.cs
@@ -1,18 +1,19 @@
 using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+
 namespace Valet.Commands;
 
-public class Version : ContainerCommand
+public class Version : BaseCommand
 {
-    private readonly string[] _args;
-
-    public Version(string[] args)
-        : base(args)
-    {
-        _args = args;
-    }
-
     protected override string Name => "version";
     protected override string Description => "Check the version of the Valet docker container.";
 
-    protected override List<Option> Options { get; } = new();
+    protected override Command GenerateCommand(App app)
+    {
+        var command = base.GenerateCommand(app);
+        
+        command.Handler = CommandHandler.Create(app.GetVersionAsync);
+
+        return command;
+    }
 }

--- a/src/Valet/Interfaces/IProcessService.cs
+++ b/src/Valet/Interfaces/IProcessService.cs
@@ -12,7 +12,7 @@ public interface IProcessService
     );
 
     Task<string> RunAndCaptureAsync(
-        string filename, 
+        string filename,
         string arguments,
         string? cwd = null,
         IEnumerable<(string, string)>? environmentVariables = null,

--- a/src/Valet/Interfaces/IProcessService.cs
+++ b/src/Valet/Interfaces/IProcessService.cs
@@ -10,4 +10,12 @@ public interface IProcessService
         bool output = true,
         string? inputForStdIn = null
     );
+
+    Task<string> RunAndCaptureAsync(
+        string filename, 
+        string arguments,
+        string? cwd = null,
+        IEnumerable<(string, string)>? environmentVariables = null,
+        bool throwOnError = true
+    );
 }

--- a/src/Valet/Program.cs
+++ b/src/Valet/Program.cs
@@ -5,19 +5,19 @@ using System.CommandLine.Parsing;
 using Valet;
 using Valet.Commands;
 using Valet.Services;
+using Version = Valet.Commands.Version;
 
 var processService = new ProcessService();
 
 var app = new App(
-    new DockerService(processService)
+    new DockerService(processService),
+    processService
 );
-
-
 
 var command = new RootCommand("Valet is a tool that facilitates migrations to GitHub Actions.")
 {
     new Update().Command(app),
-    new Valet.Commands.Version(args).Command(app),
+    new Version().Command(app),
     new Audit(args).Command(app),
     new DryRun(args).Command(app),
     new Migrate(args).Command(app),

--- a/src/Valet/Program.cs
+++ b/src/Valet/Program.cs
@@ -11,7 +11,7 @@ var processService = new ProcessService();
 
 var app = new App(
     new DockerService(processService),
-    processService
+    processService,
     new ConfigurationService()
 );
 

--- a/src/Valet/Services/ProcessService.cs
+++ b/src/Valet/Services/ProcessService.cs
@@ -42,7 +42,7 @@ public class ProcessService : IProcessService
     {
         using var process = GetProcess(filename, arguments, cwd, environmentVariables);
         process.Start();
-        
+
         await process.WaitForExitAsync();
 
         if (process.ExitCode != 0 && throwOnError)

--- a/src/Valet/Services/ProcessService.cs
+++ b/src/Valet/Services/ProcessService.cs
@@ -14,32 +14,7 @@ public class ProcessService : IProcessService
         string? inputForStdIn = null)
     {
         var cts = new CancellationTokenSource();
-
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = filename,
-            Arguments = arguments,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            RedirectStandardInput = true,
-            UseShellExecute = false,
-            WorkingDirectory = cwd,
-            CreateNoWindow = true
-        };
-
-        if (environmentVariables != null)
-        {
-            foreach (var (key, value) in environmentVariables)
-            {
-                startInfo.EnvironmentVariables.Add(key, value);
-            }
-        }
-
-        using var process = new Process
-        {
-            StartInfo = startInfo,
-            EnableRaisingEvents = true
-        };
+        using var process = GetProcess(filename, arguments, cwd, environmentVariables);
         process.Start();
 
         if (!string.IsNullOrWhiteSpace(inputForStdIn))
@@ -61,6 +36,51 @@ public class ProcessService : IProcessService
             var error = await process.StandardError.ReadToEndAsync();
             throw new Exception(error);
         }
+    }
+
+    public async Task<string> RunAndCaptureAsync(string filename, string arguments, string? cwd = null, IEnumerable<(string, string)>? environmentVariables = null, bool throwOnError = true)
+    {
+        using var process = GetProcess(filename, arguments, cwd, environmentVariables);
+        process.Start();
+        
+        await process.WaitForExitAsync();
+
+        if (process.ExitCode != 0 && throwOnError)
+        {
+            var error = await process.StandardError.ReadToEndAsync();
+            throw new Exception(error);
+        }
+
+        return await process.StandardOutput.ReadToEndAsync();
+    }
+
+    private Process GetProcess(string filename, string arguments, string? cwd = null, IEnumerable<(string, string)>? environmentVariables = null)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = filename,
+            Arguments = arguments,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            UseShellExecute = false,
+            WorkingDirectory = cwd,
+            CreateNoWindow = true
+        };
+
+        if (environmentVariables != null)
+        {
+            foreach (var (key, value) in environmentVariables)
+            {
+                startInfo.EnvironmentVariables.Add(key, value);
+            }
+        }
+
+        return new Process
+        {
+            StartInfo = startInfo,
+            EnableRaisingEvents = true
+        };
     }
 
     private void ReadStream(StreamReader reader, bool output, CancellationToken ctx)


### PR DESCRIPTION
## What's changing?

This creates a single `version` command that can be used to fetch the `gh` version, the `gh-valet` version, and the valet docker image all in one go. This will make the support request form simpler since now folks can send the output of a single command instead of 3. Further enhancements can be done to indicate if there are more recent versions of the valet-cli 
 image available.

## How's this tested?

```bash
$ dotnet run --project src/Valet/Valet.csproj -- version
gh version 2.11.3 (2022-05-25)
gh valet        github/gh-valet v0.1.10
valet-cli       v0.1.0.12957
```

Closes #35 
