### PR TITLE
Escape arguments containing spaces

### DIFF
--- a/src/Valet.UnitTests/Models/StringExtensionsTests.cs
+++ b/src/Valet.UnitTests/Models/StringExtensionsTests.cs
@@ -1,0 +1,15 @@
+using NUnit.Framework;
+using Valet.Models;
+
+namespace Valet.UnitTests.Models;
+
+[TestFixture]
+public class StringExtensionsTests
+{
+    [TestCase("name with spaces", "\"name with spaces\"")]
+    [TestCase("name-with-no-spaces", "name-with-no-spaces")]
+    public void EscapeIfNeeded_ReturnsExpected(string input, string expected)
+    {
+        Assert.AreEqual(expected, input.EscapeIfNeeded());
+    }
+}

--- a/src/Valet/App.cs
+++ b/src/Valet/App.cs
@@ -1,4 +1,5 @@
 using Valet.Interfaces;
+using Valet.Models;
 
 namespace Valet;
 
@@ -41,12 +42,12 @@ public class App
             ValetContainerRegistry,
             "latest"
         ).ConfigureAwait(false);
-
+        
         await _dockerService.ExecuteCommandAsync(
             ValetImage,
             ValetContainerRegistry,
             "latest",
-            args
+            args.Select(x => x.EscapeIfNeeded()).ToArray()
         );
         return 0;
     }

--- a/src/Valet/App.cs
+++ b/src/Valet/App.cs
@@ -46,7 +46,7 @@ public class App
             ValetContainerRegistry,
             "latest"
         ).ConfigureAwait(false);
-        
+
         await _dockerService.ExecuteCommandAsync(
             ValetImage,
             ValetContainerRegistry,

--- a/src/Valet/Commands/Audit.cs
+++ b/src/Valet/Commands/Audit.cs
@@ -16,7 +16,8 @@ public class Audit : BaseCommand
     private static readonly Option<string[]> FoldersOption = new(new[] { "-f", "--folders" })
     {
         Description = "Folders to audit in the instance",
-        IsRequired = false
+        IsRequired = false,
+        AllowMultipleArgumentsPerToken = true
     };
 
     protected override Command GenerateCommand(App app)

--- a/src/Valet/Commands/Common.cs
+++ b/src/Valet/Commands/Common.cs
@@ -18,7 +18,8 @@ public static class Common
         command.AddGlobalOption(
             new Option<string[]>(new[] { "--allowed-actions" })
             {
-                Description = "An allowed list of GitHub actions to map to."
+                Description = "An allowed list of GitHub actions to map to.",
+                AllowMultipleArgumentsPerToken = true
             }
         );
 
@@ -47,7 +48,8 @@ public static class Common
         command.AddGlobalOption(
             new Option<FileInfo[]>(new[] { "--custom-transformers" })
             {
-                Description = "Paths to custom transformers."
+                Description = "Paths to custom transformers.",
+                AllowMultipleArgumentsPerToken = true
             }
         );
 

--- a/src/Valet/Commands/Forecast.cs
+++ b/src/Valet/Commands/Forecast.cs
@@ -29,6 +29,7 @@ public class Forecast : BaseCommand
     {
         Description = "The file path(s) to existing jobs data.",
         IsRequired = false,
+        AllowMultipleArgumentsPerToken = true
     };
 
     protected override Command GenerateCommand(App app)

--- a/src/Valet/Commands/GitLab/Common.cs
+++ b/src/Valet/Commands/GitLab/Common.cs
@@ -14,6 +14,7 @@ public static class Common
     {
         Description = "The GitLab namespace(s).",
         IsRequired = false,
+        AllowMultipleArgumentsPerToken = true
     };
 
     public static readonly Option<string> AccessToken = new("--gitlab-access-token")

--- a/src/Valet/Commands/GitLab/Common.cs
+++ b/src/Valet/Commands/GitLab/Common.cs
@@ -10,7 +10,7 @@ public static class Common
         IsRequired = false,
     };
 
-    public static readonly Option<string> Namespace = new("--namespace")
+    public static readonly Option<string[]> Namespace = new("--namespace")
     {
         Description = "The GitLab namespace(s).",
         IsRequired = false,

--- a/src/Valet/Commands/Jenkins/Forecast.cs
+++ b/src/Valet/Commands/Jenkins/Forecast.cs
@@ -14,7 +14,8 @@ public class Forecast : ContainerCommand
     private static readonly Option<string[]> FoldersOption = new(new[] { "-f", "--folders" })
     {
         Description = "Folders to forecast in the instance",
-        IsRequired = false
+        IsRequired = false,
+        AllowMultipleArgumentsPerToken = true
     };
 
     protected override List<Option> Options => new()

--- a/src/Valet/Models/StringExtensions.cs
+++ b/src/Valet/Models/StringExtensions.cs
@@ -1,0 +1,12 @@
+namespace Valet.Models;
+
+public static class StringExtensions
+{
+    public static string EscapeIfNeeded(this string str)
+    {
+        if (!str.Contains(' '))
+            return str;
+        
+        return $"\"{str}\"";
+    }
+}

--- a/src/Valet/Models/StringExtensions.cs
+++ b/src/Valet/Models/StringExtensions.cs
@@ -4,9 +4,6 @@ public static class StringExtensions
 {
     public static string EscapeIfNeeded(this string str)
     {
-        if (!str.Contains(' '))
-            return str;
-        
-        return $"\"{str}\"";
+        return !str.Contains(' ') ? str : $"\"{str}\"";
     }
 }


### PR DESCRIPTION
## What's changing?

This ensures that arguments that contain a space have their spaces preserved when delegated to the valet-cli container. 

Additionally, this updates the `Option`s that are an array type to accept multiple input. This means that this is valid syntax once again `gh valet audit gitlab --namespace first second third -o output`

## How's this tested?

- Specs

```bash
$ dotnet run --project src/Valet/Valet.csproj -- audit azure-devops --azure-devops-project "name with spaces" -o output
```

Closes valet-customers/issue-ops#3
