### PR TITLE
Add --no-http-cache option and refactor options

### DIFF
--- a/src/Valet/Commands/Audit.cs
+++ b/src/Valet/Commands/Audit.cs
@@ -22,7 +22,7 @@ public class Audit : BaseCommand
     protected override Command GenerateCommand(App app)
     {
         var command = base.GenerateCommand(app);
-        command = Common.AppendCommonOptions(command);
+        command.AppendCommonOptions();
 
         command.AddGlobalOption(FoldersOption);
         command.AddCommand(new AzureDevOps.Audit(_args).Command(app));

--- a/src/Valet/Commands/Common.cs
+++ b/src/Valet/Commands/Common.cs
@@ -5,16 +5,9 @@ namespace Valet.Commands;
 
 public static class Common
 {
-    public static Command AppendCommonOptions(Command command)
-    {
-        command.AddGlobalOption(
-            new Option<DirectoryInfo>(new[] { "--output-dir", "-o" })
-            {
-                IsRequired = true,
-                Description = "The location for any output files."
-            }
-        );
 
+    public static Command AppendTransformerOptions(Command command)
+    {
         command.AddGlobalOption(
             new Option<string[]>(new[] { "--allowed-actions" })
             {
@@ -28,7 +21,6 @@ public static class Common
                 Description = "Boolean value to only allow verified actions."
             }
         );
-
 
         command.AddGlobalOption(
             new Option<bool>(new[] { "--allow-github-created-actions" })
@@ -51,6 +43,19 @@ public static class Common
             }
         );
 
+        // TODO: Add in enum values
+        command.AddGlobalOption(
+            new Option<string>(new[] { "--features" })
+            {
+                Description = "Features to enable in transformed workflows."
+            }
+        );
+
+        return command;
+    }
+
+    public static Command AppendGeneralOptions(Command command)
+    {
         command.AddGlobalOption(
             new Option<string>(new[] { "--credentials-file" })
             {
@@ -72,13 +77,34 @@ public static class Common
             }
         );
 
-        // TODO: Add in enum values
         command.AddGlobalOption(
-            new Option<string>(new[] { "--features" })
+            new Option<bool>(new[] { "--no-http-cache" })
             {
-                Description = "Features to enable in transformed workflows."
+                Description = "Disable caching of http responses."
             }
         );
+
+        return command;
+    }
+
+    public static Command AppendGeneralRequiredOptions(Command command)
+    {
+        command.AddGlobalOption(
+            new Option<DirectoryInfo>(new[] { "--output-dir", "-o" })
+            {
+                IsRequired = true,
+                Description = "The location for any output files."
+            }
+        );
+
+        return command;
+    }
+
+    public static Command AppendCommonOptions(Command command)
+    {
+        command = AppendGeneralRequiredOptions(command);
+        command = AppendTransformerOptions(command);
+        command = AppendGeneralOptions(command);
 
         return command;
     }

--- a/src/Valet/Commands/Common.cs
+++ b/src/Valet/Commands/Common.cs
@@ -43,7 +43,6 @@ public static class Common
             }
         );
 
-        // TODO: Add in enum values
         command.AddGlobalOption(
             new Option<string>(new[] { "--features" })
             {

--- a/src/Valet/Commands/Common.cs
+++ b/src/Valet/Commands/Common.cs
@@ -6,7 +6,7 @@ namespace Valet.Commands;
 public static class Common
 {
 
-    public static Command AppendTransformerOptions(Command command)
+    public static Command AppendTransformerOptions(this Command command)
     {
         command.AddGlobalOption(
             new Option<string[]>(new[] { "--allowed-actions" })
@@ -54,7 +54,7 @@ public static class Common
         return command;
     }
 
-    public static Command AppendGeneralOptions(Command command)
+    public static Command AppendGeneralOptions(this Command command)
     {
         command.AddGlobalOption(
             new Option<string>(new[] { "--credentials-file" })
@@ -87,7 +87,7 @@ public static class Common
         return command;
     }
 
-    public static Command AppendGeneralRequiredOptions(Command command)
+    public static Command AppendGeneralRequiredOptions(this Command command)
     {
         command.AddGlobalOption(
             new Option<DirectoryInfo>(new[] { "--output-dir", "-o" })
@@ -100,12 +100,10 @@ public static class Common
         return command;
     }
 
-    public static Command AppendCommonOptions(Command command)
+    public static void AppendCommonOptions(this Command command)
     {
-        command = AppendGeneralRequiredOptions(command);
-        command = AppendTransformerOptions(command);
-        command = AppendGeneralOptions(command);
-
-        return command;
+        command.AppendGeneralRequiredOptions()
+               .AppendTransformerOptions()
+               .AppendGeneralOptions();
     }
 }

--- a/src/Valet/Commands/DryRun.cs
+++ b/src/Valet/Commands/DryRun.cs
@@ -16,7 +16,7 @@ public class DryRun : BaseCommand
     protected override Command GenerateCommand(App app)
     {
         var command = base.GenerateCommand(app);
-        command = Common.AppendCommonOptions(command);
+        command.AppendCommonOptions();
 
         command.AddCommand(new AzureDevOps.DryRun(_args).Command(app));
         command.AddCommand(new Circle.DryRun(_args).Command(app));

--- a/src/Valet/Commands/Forecast.cs
+++ b/src/Valet/Commands/Forecast.cs
@@ -34,18 +34,13 @@ public class Forecast : BaseCommand
     protected override Command GenerateCommand(App app)
     {
         var command = base.GenerateCommand(app);
-
-        command.AddGlobalOption(
-            new Option<DirectoryInfo>(new[] { "--output-dir", "-o" })
-            {
-                IsRequired = true,
-                Description = "The location for any output files."
-            }
-        );
+        command = Common.AppendGeneralRequiredOptions(command);
 
         command.AddGlobalOption(StartDate);
         command.AddGlobalOption(TimeSlice);
         command.AddGlobalOption(SourceFilePath);
+
+        command = Common.AppendGeneralOptions(command);
 
         command.AddCommand(new AzureDevOps.Forecast(_args).Command(app));
         command.AddCommand(new Jenkins.Forecast(_args).Command(app));

--- a/src/Valet/Commands/Forecast.cs
+++ b/src/Valet/Commands/Forecast.cs
@@ -34,13 +34,13 @@ public class Forecast : BaseCommand
     protected override Command GenerateCommand(App app)
     {
         var command = base.GenerateCommand(app);
-        command = Common.AppendGeneralRequiredOptions(command);
+        command.AppendGeneralRequiredOptions();
 
         command.AddGlobalOption(StartDate);
         command.AddGlobalOption(TimeSlice);
         command.AddGlobalOption(SourceFilePath);
 
-        command = Common.AppendGeneralOptions(command);
+        command.AppendGeneralOptions();
 
         command.AddCommand(new AzureDevOps.Forecast(_args).Command(app));
         command.AddCommand(new Jenkins.Forecast(_args).Command(app));

--- a/src/Valet/Commands/Migrate.cs
+++ b/src/Valet/Commands/Migrate.cs
@@ -34,7 +34,7 @@ public class Migrate : BaseCommand
     protected override Command GenerateCommand(App app)
     {
         var command = base.GenerateCommand(app);
-        command = Common.AppendCommonOptions(command);
+        command.AppendCommonOptions();
 
         command.AddGlobalOption(TargetUrl);
         command.AddGlobalOption(GitHubInstanceUrl);


### PR DESCRIPTION
## What's changing?
Adds the --no-http-cache option to gh-valet and refactors the options to split options that are specific to transformer commands (`audit`, `dry-run`, `migrate`) from options that should be enabled for all commands including `forecast`

PS. Naming is hard 😆 

## How's this tested?
👀 

```
➜ dotnet run --project src/Valet/Valet.csproj -- forecast azure-devops --help
Options:
  -g, --azure-devops-organization <azure-devops-organization>  The Azure DevOps organization name.
  -p, --azure-devops-project <azure-devops-project>            The Azure DevOps project name.
  -u, --azure-devops-instance-url <azure-devops-instance-url>  The URL of the Azure DevOps instance.
  -t, --azure-devops-access-token <azure-devops-access-token>  Access token for the Azure DevOps instance.
  -o, --output-dir <output-dir> (REQUIRED)                     The location for any output files.
  --start-date <start-date>                                    The start date of the forecast analysis in YYYY-MM-DD format. [default: 6/3/2022 
                                                               12:18:37 PM]
  --time-slice <time-slice>                                    The time slice in seconds to use for computing concurrency metrics. [default: 60]
  --source-file-path <source-file-path>                        The file path(s) to existing jobs data.
  -o, --output-dir <output-dir> (REQUIRED)                     The location for any output files.
  --credentials-file <credentials-file>                        The file containing the credentials to use.
  --no-telemetry                                               Boolean value to disallow telemetry.
  --no-ssl-verify                                              Disable ssl certificate verification.
  --no-http-cache                                              Disable caching of http responses.
  -?, -h, --help                                               Show help and usage information
```

Closes [related issues]
