### PR TITLE
Check if valet container is current

### DIFF
--- a/src/Valet.UnitTests/AppTests.cs
+++ b/src/Valet.UnitTests/AppTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Moq;

--- a/src/Valet.UnitTests/AppTests.cs
+++ b/src/Valet.UnitTests/AppTests.cs
@@ -40,11 +40,11 @@ public class AppTests
 
         _dockerService.Setup(handler =>
             handler.GetLatestImageDigestAsync(image, server)
-        ).Returns(Task.FromResult(latestImage));
+        ).ReturnsAsync(latestImage);
 
         _dockerService.Setup(handler =>
             handler.GetCurrentImageDigestAsync(image, server)
-        ).Returns(Task.FromResult(currentImage));
+        ).ReturnsAsync(currentImage);
 
         // Act
         await _app.CheckForUpdatesAsync();

--- a/src/Valet.UnitTests/AppTests.cs
+++ b/src/Valet.UnitTests/AppTests.cs
@@ -44,9 +44,11 @@ public class AppTests
         ).Returns(Task.FromResult(latestImage));
 #pragma warning restore CS8620
 
+#pragma warning disable CS8620 // I don't care that this method return is nullable
         _dockerService.Setup(handler =>
             handler.GetCurrentImageDigestAsync(image, server)
         ).Returns(Task.FromResult(currentImage));
+#pragma warning restore CS8620
 
         // Act
         _app.CheckForUpdates();

--- a/src/Valet.UnitTests/AppTests.cs
+++ b/src/Valet.UnitTests/AppTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Valet.Interfaces;
+using Valet.Services;
+
+namespace Valet.UnitTests;
+
+[TestFixture]
+public class AppTests
+{
+#pragma warning disable CS8618
+    private Mock<IProcessService> _processService;
+    private Mock<IDockerService> _dockerService;
+    private Mock<IConfigurationService> _configurationService;
+    private App _app;
+#pragma warning restore CS8618
+
+    [SetUp]
+    public void BeforeEachTest()
+    {
+        _dockerService = new Mock<IDockerService>();
+        _processService = new Mock<IProcessService>();
+        _configurationService = new Mock<IConfigurationService>();
+        _app = new App(_dockerService.Object, _processService.Object, _configurationService.Object);
+    }
+
+    [TestCase("4256ea72fd01deac3e967f6b19f907587dcd6f0a976301f1aecc73dc6f146a4a", "4256ea72fd01deac3e967f6b19f907587dcd6f0a976301f1aecc73dc6f146a4a", "")]
+    [TestCase("4256ea72fd01deac3e967f6b19f907587dcd6f0a976301f1aecc73dc6f146a4a", "67eed1493c461efd993be9777598a456562f4e0c6b0bddcb19d819220a06dd4b", "A new version of the Valet CLI is available. Run 'gh valet update' to update.\n")]
+    public void CheckForUpdates_NoUpdatesNeeded(string latestImage, string currentImage, string result)
+    {
+        // Arrange
+        var image = "valet-customers/valet-cli";
+        var server = "ghcr.io";
+
+        var stringWriter = new StringWriter();
+        Console.SetOut(stringWriter);
+
+#pragma warning disable CS8620 // I don't care that this method return is nullable
+        _dockerService.Setup(handler =>
+            handler.GetLatestImageDigestAsync(image, server)
+        ).Returns(Task.FromResult(latestImage));
+#pragma warning restore CS8620
+
+        _dockerService.Setup(handler =>
+            handler.GetCurrentImageDigestAsync(image, server)
+        ).Returns(Task.FromResult(currentImage));
+
+        // Act
+        _app.CheckForUpdates();
+
+        // Act, Assert
+        Assert.AreEqual(result, stringWriter.ToString());
+        _processService.VerifyAll();
+    }
+
+    [Test]
+    public void CheckForUpdates_RaisesCaughtException()
+    {
+        // Arrange
+        var image = "valet-customers/valet-cli";
+        var server = "ghcr.io";
+
+        var stringWriter = new StringWriter();
+        Console.SetOut(stringWriter);
+
+        _dockerService.Setup(handler =>
+            handler.GetLatestImageDigestAsync(image, server)
+        ).ThrowsAsync(new Exception());
+
+        // Act
+        _app.CheckForUpdates();
+
+        // Act, Assert
+        Assert.AreEqual("", stringWriter.ToString());
+        _processService.VerifyAll();
+    }
+}

--- a/src/Valet.UnitTests/AppTests.cs
+++ b/src/Valet.UnitTests/AppTests.cs
@@ -29,7 +29,7 @@ public class AppTests
 
     [TestCase("4256ea72fd01deac3e967f6b19f907587dcd6f0a976301f1aecc73dc6f146a4a", "4256ea72fd01deac3e967f6b19f907587dcd6f0a976301f1aecc73dc6f146a4a", "")]
     [TestCase("4256ea72fd01deac3e967f6b19f907587dcd6f0a976301f1aecc73dc6f146a4a", "67eed1493c461efd993be9777598a456562f4e0c6b0bddcb19d819220a06dd4b", "A new version of the Valet CLI is available. Run 'gh valet update' to update.\n")]
-    public void CheckForUpdates_NoUpdatesNeeded(string latestImage, string currentImage, string result)
+    public async Task CheckForUpdates_NoUpdatesNeeded(string? latestImage, string? currentImage, string result)
     {
         // Arrange
         var image = "valet-customers/valet-cli";
@@ -38,28 +38,24 @@ public class AppTests
         var stringWriter = new StringWriter();
         Console.SetOut(stringWriter);
 
-#pragma warning disable CS8620 // I don't care that this method return is nullable
         _dockerService.Setup(handler =>
             handler.GetLatestImageDigestAsync(image, server)
         ).Returns(Task.FromResult(latestImage));
-#pragma warning restore CS8620
 
-#pragma warning disable CS8620 // I don't care that this method return is nullable
         _dockerService.Setup(handler =>
             handler.GetCurrentImageDigestAsync(image, server)
         ).Returns(Task.FromResult(currentImage));
-#pragma warning restore CS8620
 
         // Act
-        _app.CheckForUpdates();
+        await _app.CheckForUpdatesAsync();
 
-        // Act, Assert
+        // Assert
         Assert.AreEqual(result, stringWriter.ToString());
         _processService.VerifyAll();
     }
 
     [Test]
-    public void CheckForUpdates_RaisesCaughtException()
+    public async Task CheckForUpdates_RaisesCaughtException()
     {
         // Arrange
         var image = "valet-customers/valet-cli";
@@ -73,9 +69,9 @@ public class AppTests
         ).ThrowsAsync(new Exception());
 
         // Act
-        _app.CheckForUpdates();
+        await _app.CheckForUpdatesAsync();
 
-        // Act, Assert
+        // Assert
         Assert.AreEqual("", stringWriter.ToString());
         _processService.VerifyAll();
     }

--- a/src/Valet.UnitTests/Models/ManifestTests.cs
+++ b/src/Valet.UnitTests/Models/ManifestTests.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using Moq;
+using NUnit.Framework;
+using Valet.Models.Docker;
+
+namespace Valet.UnitTests;
+
+[TestFixture]
+public class ManifestTests
+{
+    private string manifestResult = @"
+{
+        ""schemaVersion"": 2,
+        ""mediaType"": ""application/vnd.docker.distribution.manifest.v2+json"",
+        ""config"": {
+                ""mediaType"": ""application/vnd.docker.container.image.v1+json"",
+                ""size"": 8933,
+                ""digest"": ""sha256:4256ea72fd01deac3e967f6b19f907587dcd6f0a976301f1aecc73dc6f146a4a""
+        },
+        ""layers"": [
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 2811969,
+                        ""digest"": ""sha256:540db60ca9383eac9e418f78490994d0af424aab7bf6d0e47ac8ed4e2e9bcbba""
+                },
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 1218679,
+                        ""digest"": ""sha256:98a867505730167ce0636f0811cb765ebbde11bf979c1a9839f6915f2fc3b85b""
+                },
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 222,
+                        ""digest"": ""sha256:69c77620f6108dc0610cba72f77d68c271fb1b14cb0800a7a8b6aaeb8950fec9""
+                },
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 23207774,
+                        ""digest"": ""sha256:9b370d66bb9903810edd365042a2f34b7a59947c942741ab947cec1b00dc738d""
+                },
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 171,
+                        ""digest"": ""sha256:d9f4ad4e4f54edfb60dcbf3da39a0d79bb818be470a76b7aa5d940214fd6817b""
+                },
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 26977223,
+                        ""digest"": ""sha256:d75779add5fb23230f53fc7b04edd78f0ac04328d54ae8b10ffc24ae8ce53fae""
+                },
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 442547,
+                        ""digest"": ""sha256:8e1571077aa30d750261fb58d29aca90235515a7ee2b35160bc907bfed0a0353""
+                },
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 4346366,
+                        ""digest"": ""sha256:c7ca3c3f89d58546450869925f28bcb901a395d5b2f7fbf013bba9d8bca353af""
+                },
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 32,
+                        ""digest"": ""sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1""
+                }
+        ]
+}";
+    [Test]
+    public void Initialize()
+    {
+        Manifest? manifest = JsonSerializer.Deserialize<Manifest>(manifestResult);
+
+        Assert.AreEqual(2, manifest?.schemaVersion);
+        Assert.AreEqual("application/vnd.docker.distribution.manifest.v2+json", manifest?.mediaType);
+        Assert.IsInstanceOf(typeof(ManifestConfig), manifest?.config);
+        Assert.AreEqual(9, manifest?.layers?.Count);
+        Assert.IsInstanceOf(typeof(ManifestConfig), manifest?.layers?[0]);
+    }
+
+    [Test]
+    public void GetDigest()
+    {
+        Manifest? manifest = JsonSerializer.Deserialize<Manifest>(manifestResult);
+
+        Assert.AreEqual("4256ea72fd01deac3e967f6b19f907587dcd6f0a976301f1aecc73dc6f146a4a", manifest?.GetDigest());
+    }
+}

--- a/src/Valet.UnitTests/Models/ManifestTests.cs
+++ b/src/Valet.UnitTests/Models/ManifestTests.cs
@@ -70,11 +70,11 @@ public class ManifestTests
     {
         Manifest? manifest = JsonSerializer.Deserialize<Manifest>(manifestResult);
 
-        Assert.AreEqual(2, manifest?.schemaVersion);
-        Assert.AreEqual("application/vnd.docker.distribution.manifest.v2+json", manifest?.mediaType);
-        Assert.IsInstanceOf(typeof(ManifestConfig), manifest?.config);
-        Assert.AreEqual(9, manifest?.layers?.Count);
-        Assert.IsInstanceOf(typeof(ManifestConfig), manifest?.layers?[0]);
+        Assert.AreEqual(2, manifest?.SchemaVersion);
+        Assert.AreEqual("application/vnd.docker.distribution.manifest.v2+json", manifest?.MediaType);
+        Assert.IsInstanceOf(typeof(ManifestConfig), manifest?.Config);
+        Assert.AreEqual(9, manifest?.Layers?.Count);
+        Assert.IsInstanceOf(typeof(ManifestConfig), manifest?.Layers?[0]);
     }
 
     [Test]

--- a/src/Valet.UnitTests/Services/DockerServiceTests.cs
+++ b/src/Valet.UnitTests/Services/DockerServiceTests.cs
@@ -279,7 +279,7 @@ public class DockerServiceTests
     }
 
     [Test]
-    public void GetCurrentImageDigest_ParsesDigestCorrectly()
+    public async Task GetCurrentImageDigest_ParsesDigestCorrectly()
     {
         // Arrange
         var image = "valet-customers/valet-cli";
@@ -296,15 +296,15 @@ public class DockerServiceTests
         ).Returns(Task.FromResult("sha256:67eed1493c461efd993be9777598a456562f4e0c6b0bddcb19d819220a06dd4b"));
 
         // Act
-        var result = _dockerService.GetCurrentImageDigestAsync(image, server);
+        var result = await _dockerService.GetCurrentImageDigestAsync(image, server);
 
-        // Act, Assert
-        Assert.AreEqual("67eed1493c461efd993be9777598a456562f4e0c6b0bddcb19d819220a06dd4b", result.Result);
+        // Assert
+        Assert.AreEqual("67eed1493c461efd993be9777598a456562f4e0c6b0bddcb19d819220a06dd4b", result);
         _processService.VerifyAll();
     }
 
     [Test]
-    public void GetLatestImageDigest_ParsesDigestCorrectly()
+    public async Task GetLatestImageDigest_ParsesDigestCorrectly()
     {
         // Arrange
         var image = "valet-customers/valet-cli";
@@ -378,10 +378,10 @@ public class DockerServiceTests
         ).Returns(Task.FromResult(manifestResult));
 
         // Act
-        var result = _dockerService.GetLatestImageDigestAsync(image, server);
+        var result = await _dockerService.GetLatestImageDigestAsync(image, server);
 
-        // Act, Assert
-        Assert.AreEqual("4256ea72fd01deac3e967f6b19f907587dcd6f0a976301f1aecc73dc6f146a4a", result.Result);
+        // Assert
+        Assert.AreEqual("4256ea72fd01deac3e967f6b19f907587dcd6f0a976301f1aecc73dc6f146a4a", result);
         _processService.VerifyAll();
     }
 }

--- a/src/Valet.UnitTests/Services/DockerServiceTests.cs
+++ b/src/Valet.UnitTests/Services/DockerServiceTests.cs
@@ -293,7 +293,7 @@ public class DockerServiceTests
                 It.IsAny<IEnumerable<(string, string)>?>(),
                 It.IsAny<bool>()
             )
-        ).Returns(Task.FromResult("sha256:67eed1493c461efd993be9777598a456562f4e0c6b0bddcb19d819220a06dd4b"));
+        ).ReturnsAsync("sha256:67eed1493c461efd993be9777598a456562f4e0c6b0bddcb19d819220a06dd4b");
 
         // Act
         var result = await _dockerService.GetCurrentImageDigestAsync(image, server);
@@ -375,7 +375,7 @@ public class DockerServiceTests
                 It.IsAny<IEnumerable<(string, string)>?>(),
                 It.IsAny<bool>()
             )
-        ).Returns(Task.FromResult(manifestResult));
+        ).ReturnsAsync(manifestResult);
 
         // Act
         var result = await _dockerService.GetLatestImageDigestAsync(image, server);

--- a/src/Valet.UnitTests/Services/DockerServiceTests.cs
+++ b/src/Valet.UnitTests/Services/DockerServiceTests.cs
@@ -277,4 +277,111 @@ public class DockerServiceTests
         Assert.ThrowsAsync<Exception>(() => _dockerService.VerifyImagePresentAsync(image, server, version));
         _processService.VerifyAll();
     }
+
+    [Test]
+    public void GetCurrentImageDigest_ParsesDigestCorrectly()
+    {
+        // Arrange
+        var image = "valet-customers/valet-cli";
+        var server = "ghcr.io";
+
+        _processService.Setup(handler =>
+            handler.RunAndCaptureAsync(
+                "docker",
+                $"image inspect --format={{{{.Id}}}} {server}/{image}:latest",
+                It.IsAny<string?>(),
+                It.IsAny<IEnumerable<(string, string)>?>(),
+                It.IsAny<bool>()
+            )
+        ).Returns(Task.FromResult("sha256:67eed1493c461efd993be9777598a456562f4e0c6b0bddcb19d819220a06dd4b"));
+
+        // Act
+        var result = _dockerService.GetCurrentImageDigestAsync(image, server);
+
+        // Act, Assert
+        Assert.AreEqual("67eed1493c461efd993be9777598a456562f4e0c6b0bddcb19d819220a06dd4b", result.Result);
+        _processService.VerifyAll();
+    }
+
+    [Test]
+    public void GetLatestImageDigest_ParsesDigestCorrectly()
+    {
+        // Arrange
+        var image = "valet-customers/valet-cli";
+        var server = "ghcr.io";
+        var manifestResult = @"
+{
+        ""schemaVersion"": 2,
+        ""mediaType"": ""application/vnd.docker.distribution.manifest.v2+json"",
+        ""config"": {
+                ""mediaType"": ""application/vnd.docker.container.image.v1+json"",
+                ""size"": 8933,
+                ""digest"": ""sha256:4256ea72fd01deac3e967f6b19f907587dcd6f0a976301f1aecc73dc6f146a4a""
+        },
+        ""layers"": [
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 2811969,
+                        ""digest"": ""sha256:540db60ca9383eac9e418f78490994d0af424aab7bf6d0e47ac8ed4e2e9bcbba""
+                },
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 1218679,
+                        ""digest"": ""sha256:98a867505730167ce0636f0811cb765ebbde11bf979c1a9839f6915f2fc3b85b""
+                },
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 222,
+                        ""digest"": ""sha256:69c77620f6108dc0610cba72f77d68c271fb1b14cb0800a7a8b6aaeb8950fec9""
+                },
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 23207774,
+                        ""digest"": ""sha256:9b370d66bb9903810edd365042a2f34b7a59947c942741ab947cec1b00dc738d""
+                },
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 171,
+                        ""digest"": ""sha256:d9f4ad4e4f54edfb60dcbf3da39a0d79bb818be470a76b7aa5d940214fd6817b""
+                },
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 26977223,
+                        ""digest"": ""sha256:d75779add5fb23230f53fc7b04edd78f0ac04328d54ae8b10ffc24ae8ce53fae""
+                },
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 442547,
+                        ""digest"": ""sha256:8e1571077aa30d750261fb58d29aca90235515a7ee2b35160bc907bfed0a0353""
+                },
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 4346366,
+                        ""digest"": ""sha256:c7ca3c3f89d58546450869925f28bcb901a395d5b2f7fbf013bba9d8bca353af""
+                },
+                {
+                        ""mediaType"": ""application/vnd.docker.image.rootfs.diff.tar.gzip"",
+                        ""size"": 32,
+                        ""digest"": ""sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1""
+                }
+        ]
+}";
+
+        _processService.Setup(handler =>
+            handler.RunAndCaptureAsync(
+                "docker",
+                $"manifest inspect {server}/{image}:latest",
+                It.IsAny<string?>(),
+                It.IsAny<IEnumerable<(string, string)>?>(),
+                It.IsAny<bool>()
+            )
+        ).Returns(Task.FromResult(manifestResult));
+
+        // Act
+        var result = _dockerService.GetLatestImageDigestAsync(image, server);
+
+        // Act, Assert
+        Assert.AreEqual("4256ea72fd01deac3e967f6b19f907587dcd6f0a976301f1aecc73dc6f146a4a", result.Result);
+        _processService.VerifyAll();
+    }
 }

--- a/src/Valet/App.cs
+++ b/src/Valet/App.cs
@@ -74,12 +74,18 @@ public class App
         return 0;
     }
 
-    public void CheckForUpdates()
+    public async Task CheckForUpdates()
     {
         try
         {
-            var latestImageDigest = _dockerService.GetLatestImageDigestAsync(ValetImage, ValetContainerRegistry)?.Result;
-            var currentImageDigest = _dockerService.GetCurrentImageDigestAsync(ValetImage, ValetContainerRegistry).Result;
+            var latestImageDigestTask = _dockerService.GetLatestImageDigestAsync(ValetImage, ValetContainerRegistry);
+            var currentImageDigestTask = _dockerService.GetCurrentImageDigestAsync(ValetImage, ValetContainerRegistry);
+
+            await Task.WhenAll(latestImageDigestTask, currentImageDigestTask);
+
+            var latestImageDigest = latestImageDigestTask?.Result;
+            var currentImageDigest = currentImageDigestTask?.Result;
+
             if (latestImageDigest != null && currentImageDigest != null && !latestImageDigest.Equals(currentImageDigest))
             {
                 Console.WriteLine("A new version of the Valet CLI is available. Run 'gh valet update' to update.");

--- a/src/Valet/App.cs
+++ b/src/Valet/App.cs
@@ -74,7 +74,7 @@ public class App
         return 0;
     }
 
-    public async Task CheckForUpdates()
+    public async Task CheckForUpdatesAsync()
     {
         try
         {

--- a/src/Valet/App.cs
+++ b/src/Valet/App.cs
@@ -74,6 +74,23 @@ public class App
         return 0;
     }
 
+    public void CheckForUpdates()
+    {
+        try
+        {
+            var latestImageDigest = _dockerService.GetLatestImageDigestAsync(ValetImage, ValetContainerRegistry)?.Result;
+            var currentImageDigest = _dockerService.GetCurrentImageDigestAsync(ValetImage, ValetContainerRegistry).Result;
+            if (latestImageDigest != null && currentImageDigest != null && !latestImageDigest.Equals(currentImageDigest))
+            {
+                Console.WriteLine("A new version of the Valet CLI is available. Run 'gh valet update' to update.");
+            }
+        }
+        catch (Exception)
+        {
+            // Ignore for now
+        }
+    }
+
     public async Task<int> ConfigureAsync()
     {
         var currentVariables = await _configurationService.ReadCurrentVariablesAsync().ConfigureAwait(false);

--- a/src/Valet/App.cs
+++ b/src/Valet/App.cs
@@ -93,7 +93,8 @@ public class App
         }
         catch (Exception)
         {
-            // Ignore for now
+            // Let's catch and ignore any exceptions here. We don't want to kill Valet if we failed to check for updates
+            // We can add reporting here in the future to alert us of any issues
         }
     }
 

--- a/src/Valet/Interfaces/IDockerService.cs
+++ b/src/Valet/Interfaces/IDockerService.cs
@@ -12,5 +12,5 @@ public interface IDockerService
 
     Task<string?> GetLatestImageDigestAsync(string image, string server);
 
-    Task<string> GetCurrentImageDigestAsync(string image, string server);
+    Task<string?> GetCurrentImageDigestAsync(string image, string server);
 }

--- a/src/Valet/Interfaces/IDockerService.cs
+++ b/src/Valet/Interfaces/IDockerService.cs
@@ -9,4 +9,8 @@ public interface IDockerService
     Task VerifyDockerRunningAsync();
 
     Task VerifyImagePresentAsync(string image, string server, string version);
+
+    Task<string?> GetLatestImageDigestAsync(string image, string server);
+
+    Task<string> GetCurrentImageDigestAsync(string image, string server);
 }

--- a/src/Valet/Models/Docker/Manifest.cs
+++ b/src/Valet/Models/Docker/Manifest.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+
+namespace Valet.Models.Docker;
+
+public class Manifest
+{
+    public int schemaVersion { get; set; }
+    public string? mediaType { get; set; }
+    public ManifestConfig? config { get; set; }
+    public List<ManifestConfig>? layers { get; set; }
+
+    public string? GetDigest()
+    {
+        return config?.digest?.Split(':')[1].Trim();
+    }
+}

--- a/src/Valet/Models/Docker/Manifest.cs
+++ b/src/Valet/Models/Docker/Manifest.cs
@@ -1,16 +1,24 @@
 using System.Collections;
+using System.Text.Json.Serialization;
 
 namespace Valet.Models.Docker;
 
 public class Manifest
 {
-    public int schemaVersion { get; set; }
-    public string? mediaType { get; set; }
-    public ManifestConfig? config { get; set; }
-    public List<ManifestConfig>? layers { get; set; }
+    [JsonPropertyName("schemaVersion")]
+    public int SchemaVersion { get; set; }
+
+    [JsonPropertyName("mediaType")]
+    public string? MediaType { get; set; }
+
+    [JsonPropertyName("config")]
+    public ManifestConfig? Config { get; set; }
+
+    [JsonPropertyName("layers")]
+    public List<ManifestConfig>? Layers { get; set; }
 
     public string? GetDigest()
     {
-        return config?.digest?.Split(':')[1].Trim();
+        return Config?.Digest?.Split(':').ElementAtOrDefault(1)?.Trim();
     }
 }

--- a/src/Valet/Models/Docker/ManifestConfig.cs
+++ b/src/Valet/Models/Docker/ManifestConfig.cs
@@ -1,0 +1,8 @@
+namespace Valet.Models.Docker;
+
+public class ManifestConfig
+{
+    public string? mediaType { get; set; }
+    public int size { get; set; }
+    public string? digest { get; set; }
+}

--- a/src/Valet/Models/Docker/ManifestConfig.cs
+++ b/src/Valet/Models/Docker/ManifestConfig.cs
@@ -1,8 +1,15 @@
+using System.Text.Json.Serialization;
+
 namespace Valet.Models.Docker;
 
 public class ManifestConfig
 {
-    public string? mediaType { get; set; }
-    public int size { get; set; }
-    public string? digest { get; set; }
+    [JsonPropertyName("mediaType")]
+    public string? MediaType { get; set; }
+
+    [JsonPropertyName("size")]
+    public int Size { get; set; }
+
+    [JsonPropertyName("digest")]
+    public string? Digest { get; set; }
 }

--- a/src/Valet/Program.cs
+++ b/src/Valet/Program.cs
@@ -47,7 +47,7 @@ try
 {
     if (!Array.Exists(args, x => x == "update"))
     {
-        await app.CheckForUpdates();
+        await app.CheckForUpdatesAsync();
     }
     await parser.InvokeAsync(args);
     return 0;

--- a/src/Valet/Program.cs
+++ b/src/Valet/Program.cs
@@ -45,6 +45,10 @@ var parser = new CommandLineBuilder(command)
 
 try
 {
+    if (!Array.Exists(args, x => x == "update"))
+    {
+        app.CheckForUpdates();
+    }
     await parser.InvokeAsync(args);
     return 0;
 }

--- a/src/Valet/Program.cs
+++ b/src/Valet/Program.cs
@@ -47,7 +47,7 @@ try
 {
     if (!Array.Exists(args, x => x == "update"))
     {
-        app.CheckForUpdates();
+        await app.CheckForUpdates();
     }
     await parser.InvokeAsync(args);
     return 0;

--- a/src/Valet/Services/DockerService.cs
+++ b/src/Valet/Services/DockerService.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
+using System.Text.Json;
 using Valet.Interfaces;
+using Valet.Models.Docker;
 
 namespace Valet.Services;
 
@@ -87,6 +89,21 @@ public class DockerService : IDockerService
         {
             throw new Exception("Unable to locate Valet image locally. Please run `gh valet update` to fetch the latest image prior to running this command.");
         }
+    }
+
+    public async Task<string?> GetLatestImageDigestAsync(string image, string server)
+    {
+        var manifestOutput = await _processService.RunAndCaptureAsync("docker", $"manifest inspect {server}/{image}:latest");
+        Manifest? manifest = JsonSerializer.Deserialize<Manifest>(manifestOutput);
+
+        return manifest?.GetDigest();
+    }
+
+    public async Task<string> GetCurrentImageDigestAsync(string image, string server)
+    {
+        var digestOutput = await _processService.RunAndCaptureAsync("docker", $"image inspect --format={{{{.Id}}}} {server}/{image}:latest");
+
+        return digestOutput.Split(":")[1].Trim();
     }
 
     private IEnumerable<string> GetEnvironmentVariableArguments()

--- a/src/Valet/Services/DockerService.cs
+++ b/src/Valet/Services/DockerService.cs
@@ -99,11 +99,11 @@ public class DockerService : IDockerService
         return manifest?.GetDigest();
     }
 
-    public async Task<string> GetCurrentImageDigestAsync(string image, string server)
+    public async Task<string?> GetCurrentImageDigestAsync(string image, string server)
     {
         var digestOutput = await _processService.RunAndCaptureAsync("docker", $"image inspect --format={{{{.Id}}}} {server}/{image}:latest");
 
-        return digestOutput.Split(":")[1].Trim();
+        return digestOutput.Split(":").ElementAtOrDefault(1)?.Trim();
     }
 
     private IEnumerable<string> GetEnvironmentVariableArguments()


### PR DESCRIPTION
## What's changing?
Checking if the valet container image is up to date. If it is not up to date, then display a message to the user suggesting they run `gh valet update` to update their image.

## How's this tested?
Unit tests 🧪  You can also manually run it by forcing an older version of valet to be your latest version:
`docker pull ghcr.io/valet-customers/valet-cli:0.1.0.12602`
`docker image tag ghcr.io/valet-customers/valet-cli:0.1.0.12602 ghcr.io/valet-customers/valet-cli:latest`
`dotnet run --project src/Valet/Valet.csproj -- version`

Note - this functionality works for all commands _except_ update, since there would be no reason to suggest an update if they are currently updating

Closes #53 
