### PR TITLE
Configure GHCR credentials in configure command

### DIFF
--- a/src/Valet/App.cs
+++ b/src/Valet/App.cs
@@ -23,8 +23,16 @@ public class App
     {
         await _dockerService.VerifyDockerRunningAsync().ConfigureAwait(false);
 
+        var environmentVariables = await _configurationService.ReadCurrentVariablesAsync().ConfigureAwait(false);
+
         username ??= Environment.GetEnvironmentVariable("GHCR_USERNAME");
         password ??= Environment.GetEnvironmentVariable("GHCR_PASSWORD");
+
+        if (username == null)
+            environmentVariables.TryGetValue("GHCR_USERNAME", out username);
+
+        if (password == null)
+            environmentVariables.TryGetValue("GHCR_PASSWORD", out password);
 
         await _dockerService.UpdateImageAsync(
             ValetImage,

--- a/src/Valet/Constants.cs
+++ b/src/Valet/Constants.cs
@@ -6,6 +6,8 @@ public static class Constants
 {
     private static readonly List<Variable> UserInputVariables = new()
     {
+        new Variable("GHCR_USERNAME", Provider.GitHub, "GitHub handle used to authenticate with the GitHub Container Registry"),
+        new Variable("GHCR_PASSWORD", Provider.GitHub, "Personal access token to authenticate with the GitHub Container Registry"),
         new Variable("GITHUB_ACCESS_TOKEN", Provider.GitHub, "Personal access token for GitHub"),
         new Variable("GITHUB_INSTANCE_URL", Provider.GitHub, "Base url of the GitHub instance", "https://github.com"),
         new Variable("AZURE_DEVOPS_ACCESS_TOKEN", Provider.AzureDevOps, "Personal access token for Azure DevOps"),


### PR DESCRIPTION
## What's changing?

This change will store and read environment variables defined in a `.env.local` file that can be used to authenticate with GHCR to fetch new versions of the valet-cli container.  This also updates the `configure` command to interactively set these credentials.

## How's this tested?

> Configure these credentials
```bash{:copy}
dotnet run --project src/Valet/Valet.csproj -- configure
```

> Use these credentials
```bash{:copy}
dotnet run --project src/Valet/Valet.csproj -- update
```
