### PR TITLE
Mask ghcr password in prompt

### DIFF
--- a/src/Valet.UnitTests/Models/VariableTests.cs
+++ b/src/Valet.UnitTests/Models/VariableTests.cs
@@ -23,6 +23,7 @@ public class VariableTests
 
     [TestCase("USERNAME", false)]
     [TestCase("PERSONAL_ACCESS_TOKEN", true)]
+    [TestCase("SOME_PASSWORD", true)]
     public void IsPassword_ReturnsExpected(string key, bool isPassword)
     {
         // Arrange

--- a/src/Valet/Models/Variable.cs
+++ b/src/Valet/Models/Variable.cs
@@ -22,7 +22,7 @@ public readonly struct Variable
         _ => throw new ArgumentOutOfRangeException()
     };
 
-    public bool IsPassword => Key.EndsWith("ACCESS_TOKEN", StringComparison.Ordinal);
+    public bool IsPassword => Key.EndsWith("ACCESS_TOKEN", StringComparison.Ordinal) || Key.EndsWith("PASSWORD", StringComparison.Ordinal);
     public string Message { get; }
     public string? DefaultValue { get; }
 


### PR DESCRIPTION
## What's changing?

This masks the `GHCR_PASSWORD` value in the terminal prompt when running the `configure` command

## How's this tested?

> Configure these credentials
```bash{:copy}
dotnet run --project src/Valet/Valet.csproj -- configure
```

> Use these credentials
```bash{:copy}
dotnet run --project src/Valet/Valet.csproj -- update
```
