### PR TITLE
Allow for user input to control which repositories to include in a cci audit

### DIFF
--- a/src/Valet/Commands/Circle/Audit.cs
+++ b/src/Valet/Commands/Circle/Audit.cs
@@ -17,7 +17,7 @@ public class Audit : ContainerCommand
         Description = "The file path corresponding to the CircleCI configuration file.",
         IsRequired = false,
     };
-    
+
     private static readonly Option<FileInfo> IncludeFrom = new("--include-from")
     {
         Description = "The file path containing a list of line-delimited repositories to include in the audit.",

--- a/src/Valet/Commands/Circle/Audit.cs
+++ b/src/Valet/Commands/Circle/Audit.cs
@@ -17,6 +17,12 @@ public class Audit : ContainerCommand
         Description = "The file path corresponding to the CircleCI configuration file.",
         IsRequired = false,
     };
+    
+    private static readonly Option<FileInfo> IncludeFrom = new("--include-from")
+    {
+        Description = "The file path containing a list of line-delimited repositories to include in the audit.",
+        IsRequired = false,
+    };
 
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
         Common.InstanceUrl,
@@ -24,6 +30,7 @@ public class Audit : ContainerCommand
         Common.Organization,
         Common.SourceGitHubAccessToken,
         Common.SourceGitHubInstanceUrl,
-        ConfigFilePath
+        ConfigFilePath,
+        IncludeFrom
     );
 }


### PR DESCRIPTION
## What's changing?

This is adding a `--include-from` option for CircleCI audits for users to control exactly which repositories to include in an audit. This is to help scenarios where customers have a large GitHub org (>5k repos) where only a portion are configured with CircleCI. By using this option, customers can mitigate any potential API limit concerns with running an audit.

## How's this tested?

> repositories.txt
```txt
circle-yaml-aliases-example
circle-ci-ruby-example
```

```bash
$ dotnet run --project src/Valet/Valet.csproj -- audit circle-ci -o tmp --include-from repositories.txt --circle-ci-organization valet-testing-unit
```

cc/ github/valet#4539
