### PR TITLE
Update CLI with new `migrate` options 

### DIFF
--- a/src/Valet/Commands/Common.cs
+++ b/src/Valet/Commands/Common.cs
@@ -54,6 +54,22 @@ public static class Common
             }
         );
 
+        command.AddGlobalOption(
+             new Option<FileInfo[]>(new[] { "--github-instance-url" })
+             {
+                 Description = "The URL of the GitHub instance.",
+                 IsRequired = false
+             }
+         );
+
+        command.AddGlobalOption(
+            new Option<string>(new[] { "--github-access-token" })
+            {
+                Description = "Access token for the GitHub repo.",
+                IsRequired = false
+            }
+        );
+
         return command;
     }
 

--- a/src/Valet/Commands/Migrate.cs
+++ b/src/Valet/Commands/Migrate.cs
@@ -19,15 +19,15 @@ public class Migrate : BaseCommand
         IsRequired = true
     };
 
-    private static readonly Option<string> GitHubInstanceUrl = new("--github-instance-url")
+    private static readonly Option<string> WorkflowFilePrefix = new("--workflow-file-prefix")
     {
-        Description = "The URL of the GitHub instance.",
+        Description = "The prefix for the workflow file names.",
         IsRequired = false
     };
 
-    private static readonly Option<string> GitHubAccessToken = new("--github-access-token")
+    private static readonly Option<string> CommitMessage = new("--commit-message")
     {
-        Description = "Access token for the GitHub repo to migrate to.",
+        Description = "The commit message to use when committing the workflow file.",
         IsRequired = false
     };
 
@@ -37,8 +37,8 @@ public class Migrate : BaseCommand
         command.AppendCommonOptions();
 
         command.AddGlobalOption(TargetUrl);
-        command.AddGlobalOption(GitHubInstanceUrl);
-        command.AddGlobalOption(GitHubAccessToken);
+        command.AddGlobalOption(WorkflowFilePrefix);
+        command.AddGlobalOption(CommitMessage);
 
         command.AddCommand(new AzureDevOps.Migrate(_args).Command(app));
         command.AddCommand(new Circle.Migrate(_args).Command(app));


### PR DESCRIPTION
## What's changing?
- Exposes new `migrate` options for `--commit-message` and `--workflow-file-prefix`
- Moves `--github-access-token` and `--github-instance-url` to global options so they are exposed on the `dry-run`, `audit`, and `migrate` commands

## To try it out 🏃 
1. Publish changes
```
dotnet publish src/Valet/Valet.csproj -c Release -r osx-x64 --self-contained -o dist/osx-x64 --no-restore -p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true 
```

2. Update Valet
```
dist/osx-x64/gh-valet update
```

3. Run `migrate`, `dry-run` and `audit` commands
```
dist/osx-x64/gh-valet COMMAND HERE
```

## How's this tested?
👀 

Closes #76 
