### PR TITLE
Expose host INSTALLATION_TYPE env var to container

### DIFF
--- a/src/Valet/Constants.cs
+++ b/src/Valet/Constants.cs
@@ -39,7 +39,8 @@ public static class Constants
             var environmentVariables = new List<string>
             {
                 "GH_ACCESS_TOKEN", "GH_INSTANCE_URL",
-                "YAML_VERBOSITY", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "OCTOKIT_PROXY", "OCTOKIT_SSL_VERIFY_MODE"
+                "YAML_VERBOSITY", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "OCTOKIT_PROXY", "OCTOKIT_SSL_VERIFY_MODE",
+                "INSTALLATION_TYPE"
             };
             environmentVariables.AddRange(UserInputVariables.Select(x => x.Key));
 


### PR DESCRIPTION
## What's changing?

This relays the `INSTALLATION_TYPE` environment variable to the valet-cli container when running from `gh valet ...`

## How's this tested?

Needs github/valet#4615
Needs github/valet.services#27

