### PR TITLE
Remove legacy prompts

### DIFF
--- a/src/Valet/Commands/Circle/Common.cs
+++ b/src/Valet/Commands/Circle/Common.cs
@@ -30,13 +30,13 @@ public static class Common
 
     public static readonly Option<string> SourceGitHubAccessToken = new(new[] { "-s", "--circle-ci-source-github-access-token" })
     {
-        Description = "Access token for the source GitHub instance.",
+        Description = "Access token for the source GitHub instance (if different than the `--github-access-token` value).",
         IsRequired = false,
     };
 
     public static readonly Option<string> SourceGitHubInstanceUrl = new(new[] { "-i", "--circle-ci-source-github-instance-url" })
     {
-        Description = "The URL of the source GitHub instance.",
+        Description = "The URL of the source GitHub instance (if different than the `--github-instance-rul` value).",
         IsRequired = false,
     };
 

--- a/src/Valet/Commands/Jenkins/Common.cs
+++ b/src/Valet/Commands/Jenkins/Common.cs
@@ -24,7 +24,7 @@ public static class Common
 
     public static readonly Option<string> JenkinsfileAccessToken = new("--jenkinsfile-access-token")
     {
-        Description = "Access token for the GitHub repo containing the job's Jenkinsfile for a pipeline.",
+        Description = "Access token for the GitHub repo containing the job's Jenkinsfile for a pipeline (if different than the `--github-access-token` value).",
         IsRequired = false,
     };
 

--- a/src/Valet/Commands/Travis/Common.cs
+++ b/src/Valet/Commands/Travis/Common.cs
@@ -24,13 +24,13 @@ public static class Common
 
     public static readonly Option<string> SourceGitHubAccessToken = new(new[] { "-s", "--travis-ci-source-github-access-token" })
     {
-        Description = "Access token for the source GitHub instance.",
+        Description = "Access token for the source GitHub instance (if different than the `--github-access-token` value).",
         IsRequired = false,
     };
 
     public static readonly Option<string> SourceGitHubInstanceUrl = new(new[] { "-i", "--travis-ci-source-github-instance-url" })
     {
-        Description = "The URL of the source GitHub instance.",
+        Description = "The URL of the source GitHub instance (if different than the `--github-instance-url` value).",
         IsRequired = false,
     };
 

--- a/src/Valet/Constants.cs
+++ b/src/Valet/Constants.cs
@@ -17,19 +17,14 @@ public static class Constants
         new Variable("CIRCLE_CI_ACCESS_TOKEN", Provider.CircleCI, "Personal access token for CircleCI"),
         new Variable("CIRCLE_CI_INSTANCE_URL", Provider.CircleCI, "Base url of the CircleCI instance", "https://circleci.com"),
         new Variable("CIRCLE_CI_ORGANIZATION", Provider.CircleCI, "CircleCI organization name"),
-        new Variable("CIRCLE_CI_SOURCE_GITHUB_ACCESS_TOKEN", Provider.CircleCI, "Personal access token to fetch source code in GitHub", "$GITHUB_ACCESS_TOKEN"),
-        new Variable("CIRCLE_CI_SOURCE_GITHUB_INSTANCE_URL", Provider.CircleCI, "Base url of the GitHub instance containing the source code", "https://github.com"),
         new Variable("GITLAB_ACCESS_TOKEN", Provider.GitLabCI, "Private token for GitLab"),
         new Variable("GITLAB_INSTANCE_URL", Provider.GitLabCI, "Base url of the GitLab instance", "https://gitlab.com"),
         new Variable("JENKINS_ACCESS_TOKEN", Provider.Jenkins, "Personal access token for Jenkins"),
         new Variable("JENKINS_USERNAME", Provider.Jenkins, "Username of Jenkins user"),
         new Variable("JENKINS_INSTANCE_URL", Provider.Jenkins, "Base url of the Jenkins instance"),
-        new Variable("JENKINSFILE_ACCESS_TOKEN", Provider.Jenkins, "Personal access token to fetch source code in GitHub", "$GITHUB_ACCESS_TOKEN"),
         new Variable("TRAVIS_CI_ACCESS_TOKEN", Provider.TravisCI, "Personal access token for Travis CI"),
         new Variable("TRAVIS_CI_INSTANCE_URL", Provider.TravisCI, "Base url of the Travis CI instance", "https://travis-ci.com"),
-        new Variable("TRAVIS_CI_ORGANIZATION", Provider.TravisCI, "Travis CI organization name"),
-        new Variable("TRAVIS_CI_SOURCE_GITHUB_ACCESS_TOKEN", Provider.TravisCI, "Personal access token to fetch source code in GitHub", "$GITHUB_ACCESS_TOKEN"),
-        new Variable("TRAVIS_CI_SOURCE_GITHUB_INSTANCE_URL", Provider.TravisCI, "Base url of the GitHub instance containing the source code", "https://github.com"),
+        new Variable("TRAVIS_CI_ORGANIZATION", Provider.TravisCI, "Travis CI organization name")
     };
 
     public static List<string> EnvironmentVariables


### PR DESCRIPTION
## What's changing?

This updates the `configure` prompt to remove the `*_SOURCE_GITHUB_(ACCESS_TOKEN|INSTANCE_URL)` options as they are not needed for the vast majority of use cases. They can still be provided as environment variables or cli options, but we now default to reusing the values for `GITHUB_ACCESS_TOKEN` and `GITHUB_INSTANCE_URL` instead.

## How's this tested?

```console
$ dotnet run --project src/Valet/Valet.csproj -- configure
A new version of the Valet CLI is available. Run 'gh valet update' to update.
✔ Which CI providers are you configuring?: Jenkins
Enter the following values (leave empty to omit):
✔ GitHub handle used to authenticate with the GitHub Container Registry: 
✔ Personal access token to authenticate with the GitHub Container Registry: 
✔ Personal access token for GitHub: 
✔ Base url of the GitHub instance: https://github.com
✔ Personal access token for Jenkins: 
✔ Username of Jenkins user: 
✔ Base url of the Jenkins instance: 
Environment variables successfully updated.
```
