### PR TITLE
Fix console output hanging while Valet processes

### DIFF
--- a/src/Valet/Services/ProcessService.cs
+++ b/src/Valet/Services/ProcessService.cs
@@ -5,8 +5,6 @@ namespace Valet.Services;
 
 public class ProcessService : IProcessService
 {
-    private static readonly object ConsoleWriterLock = new();
-
     public async Task RunAsync(
         string filename,
         string arguments,
@@ -91,21 +89,11 @@ public class ProcessService : IProcessService
         {
             while (!ctx.IsCancellationRequested)
             {
-                int current = reader.Read();
-
-                if (current >= 0)
+                int current;
+                while ((current = reader.Read()) >= 0)
                 {
-                    lock (ConsoleWriterLock)
-                    {
-                        while (current >= 0)
-                        {
-                            if (output)
-                            {
-                                Console.Write((char)current);
-                            }
-                            current = reader.Read();
-                        }
-                    }
+                    if (output)
+                        Console.Write((char)current);
                 }
             }
         }, ctx);


### PR DESCRIPTION
## What's changing?

This reverts commit 5fc0e49cfe34342f33154675cec73799520a0746.

The commit above was causing output to not print to the console until the process was finished.

## How's this tested?
```
dotnet run --project src/Valet/Valet.csproj -- audit azure-devops -o tmp
```
