### PR TITLE
GitHub forecast subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Commands:
   gitlab        Forecasts GitHub Actions usage from historical GitLab pipeline utilization.
   circle-ci     Forecasts GitHub Actions usage from historical CircleCI pipeline utilization.
   travis-ci     Forecasts GitHub Actions usage from historical Travis CI pipeline utilization.
+  github        Forecasts GitHub Actions usage from historical GitHub pipeline utilization.
 ```
 
 You can find detailed information about running a forecast with Valet in the documentation that is available once you are granted access.

--- a/src/Valet/Commands/Forecast.cs
+++ b/src/Valet/Commands/Forecast.cs
@@ -52,6 +52,7 @@ public class Forecast : ContainerCommand
         command.AddCommand(new GitLab.Forecast(_args).Command(app));
         command.AddCommand(new Circle.Forecast(_args).Command(app));
         command.AddCommand(new Travis.Forecast(_args).Command(app));
+        command.AddCommand(new GitHub.Forecast(_args).Command(app));
 
         return command;
     }

--- a/src/Valet/Commands/GitHub/Forecast.cs
+++ b/src/Valet/Commands/GitHub/Forecast.cs
@@ -1,0 +1,53 @@
+using System.Collections.Immutable;
+using System.CommandLine;
+
+namespace Valet.Commands.GitHub;
+
+public class Forecast : ContainerCommand
+{
+    public Forecast(string[] args) : base(args)
+    {
+    }
+
+    protected override string Name => "github";
+    protected override string Description => "Forecasts GitHub Actions usage from historical GitHub pipeline utilization.";
+
+    public static readonly Option<string> InstanceUrl = new("--github-instance-url")
+    {
+        Description = "The URL of the GitHub instance.",
+        IsRequired = false,
+    };
+
+    public static readonly Option<string> AccessToken = new("--github-access-token")
+    {
+        Description = "Access token for the GitHub instance.",
+        IsRequired = false,
+    };
+
+    public static readonly Option<string> Organization = new("--organization")
+    {
+        Description = "The GitHub organization name.",
+        IsRequired = true,
+    };
+
+    public static readonly Option<string> Repository = new("--repository")
+    {
+        Description = "The GitHub repository name.",
+        IsRequired = false,
+    };
+
+    private static readonly Option<FileInfo[]> SourceFilePath = new("--source-file-path")
+    {
+        Description = "The file path(s) to existing jobs data.",
+        IsRequired = false,
+        AllowMultipleArgumentsPerToken = true,
+    };
+
+    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        InstanceUrl,
+        AccessToken,
+        Organization,
+        Repository,
+        SourceFilePath
+    );
+}

--- a/src/Valet/Commands/GitHub/Forecast.cs
+++ b/src/Valet/Commands/GitHub/Forecast.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.CommandLine;
 
 namespace Valet.Commands.GitHub;

--- a/src/Valet/Commands/GitHub/Forecast.cs
+++ b/src/Valet/Commands/GitHub/Forecast.cs
@@ -12,25 +12,25 @@ public class Forecast : ContainerCommand
     protected override string Name => "github";
     protected override string Description => "Forecasts GitHub Actions usage from historical GitHub pipeline utilization.";
 
-    public static readonly Option<string> InstanceUrl = new("--github-instance-url")
+    public static readonly Option<string> InstanceUrl = new(new[] { "--github-instance-url", "-u" })
     {
         Description = "The URL of the GitHub instance.",
         IsRequired = false,
     };
 
-    public static readonly Option<string> AccessToken = new("--github-access-token")
+    public static readonly Option<string> AccessToken = new(new[] { "--github-access-token", "-t" })
     {
         Description = "Access token for the GitHub instance.",
         IsRequired = false,
     };
 
-    public static readonly Option<string> Organization = new("--organization")
+    public static readonly Option<string> Organization = new(new[] { "--organization", "-g" })
     {
         Description = "The GitHub organization name.",
         IsRequired = true,
     };
 
-    public static readonly Option<string> Repository = new("--repository")
+    public static readonly Option<string> Repository = new(new[] { "--repository", "-r" })
     {
         Description = "The GitHub repository name.",
         IsRequired = false,


### PR DESCRIPTION
## What's changing?
Adding the GitHub forecast subcommand to gh valet.

## How's this tested?

`dotnet run --project src/Valet/Valet.csproj -- forecast github --organization valet-dev-testing -o tmp`

`dotnet run --project src/Valet/Valet.csproj -- forecast github -o valet-testing-unit -o tmp`

`dotnet run --project src/Valet/Valet.csproj -- forecast github --organization github -r valet -o tmp` (if you have SSO enabled for your github token)

Closes #85 
