### PR TITLE
Revert parallel console writes

### DIFF
--- a/src/Valet/Services/ProcessService.cs
+++ b/src/Valet/Services/ProcessService.cs
@@ -5,8 +5,6 @@ namespace Valet.Services;
 
 public class ProcessService : IProcessService
 {
-    private static readonly object ConsoleWriterLock = new();
-
     public async Task RunAsync(
         string filename,
         string arguments,
@@ -91,21 +89,11 @@ public class ProcessService : IProcessService
         {
             while (!ctx.IsCancellationRequested)
             {
-                int current = reader.Read();
-
-                if (current >= 0)
+                int current;
+                while ((current = reader.Read()) >= 0)
                 {
-                    lock (ConsoleWriterLock)
-                    {
-                        while (current >= 0)
-                        {
-                            if (output)
-                            {
-                                Console.Write((char)current);
-                            }
-                            current = reader.Read();
-                        }
-                    }
+                    if (output)
+                        Console.Write((char)current);
                 }
             }
         }, ctx);

--- a/src/Valet/Services/ProcessService.cs
+++ b/src/Valet/Services/ProcessService.cs
@@ -27,11 +27,8 @@ public class ProcessService : IProcessService
             writer.Close();
         }
 
-        if (output)
-        {
-            ReadStream(process.StandardOutput, cts.Token);
-            ReadStream(process.StandardError, cts.Token);
-        }
+        ReadStream(process.StandardOutput, output, cts.Token);
+        ReadStream(process.StandardError, output, cts.Token);
 
         await process.WaitForExitAsync(cts.Token);
 
@@ -88,7 +85,7 @@ public class ProcessService : IProcessService
         };
     }
 
-    private static void ReadStream(StreamReader reader, CancellationToken ctx)
+    private static void ReadStream(StreamReader reader, bool output, CancellationToken ctx)
     {
         Task.Run(() =>
         {
@@ -102,11 +99,9 @@ public class ProcessService : IProcessService
                     {
                         while (current >= 0)
                         {
-                            Console.Write((char)current);
-
-                            if (reader.Peek() == -1)
+                            if (output)
                             {
-                                break;
+                                Console.Write((char)current);
                             }
                             current = reader.Read();
                         }


### PR DESCRIPTION
## What's changing?
Reverting two changes made that prevent gh-valet from writing stderr and stdout to the console. These changes were causing output hangs for windows machines. We need to pull out these changes until we come up with a more robust solution that works for all machines.

**Note** - We are still working on a different fix. If there's a quick fix we can make to resolve the Windows issues, then we won't merge these changes.

## How's this tested?
Manually ran various commands to ensure they work as expected

Closes #89 
