### PR TITLE
Additional docker auth error mesage 

### DIFF
--- a/src/Valet/Services/DockerService.cs
+++ b/src/Valet/Services/DockerService.cs
@@ -161,12 +161,17 @@ public class DockerService : IDockerService
         if (exitCode != 0)
         {
             string message = standardError.Trim();
-            string? errorMessage = message == "Error response from daemon: denied"
-                ? @"You are not authorized to access Valet yet. Please ensure you've completed the following:
+            string errorMessage = $"There was an error pulling the {image}:{version} image from the {server} docker repository.\nError: {message}";
+
+            if (message == "Error response from daemon: denied"
+                || message == $"Error response from daemon: Head \"https://{server}/v2/valet-customers/valet-cli/manifests/latest\": unauthorized")
+            {
+                errorMessage = @"You are not authorized to access Valet yet. Please ensure you've completed the following:
 - Requested access to Valet and received onboarding instructions via email.
 - Accepted all of the repository invites sent after being onboarded.
-- The GitHub personal access token used above contains the 'read:packages' scope."
-                : $"There was an error pulling the {image}:{version} image from the {server} docker repository.\nError: {message}";
+- The GitHub personal access token used above contains the 'read:packages' scope.";
+            }
+
             throw new Exception(errorMessage);
         }
         Console.WriteLine($"Successfully downloaded {image}:{version}");


### PR DESCRIPTION
## What's changing?

Adds 1 additional check for docker authentication error messages to apply user-friendly formatting

## How's this tested?

On a new, clean installation w/o valid docker credentials cached or providing valid credentials as input, run the `gh valet update` call and verify that the user is presented with the friendly error message rather than the `Error response from daemon` error that Docker returns
