### PR TITLE
Updating options on GH-Valet with new ADO options 

### DIFF
--- a/src/Valet/Commands/AzureDevOps/Audit.cs
+++ b/src/Valet/Commands/AzureDevOps/Audit.cs
@@ -20,6 +20,7 @@ public class Audit : ContainerCommand
     };
 
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        ConfigFilePath,
         Common.Organization,
         Common.Project,
         Common.InstanceUrl,

--- a/src/Valet/Commands/AzureDevOps/Audit.cs
+++ b/src/Valet/Commands/AzureDevOps/Audit.cs
@@ -13,6 +13,12 @@ public class Audit : ContainerCommand
     protected override string Name => "azure-devops";
     protected override string Description => "An audit will output a list of data used in an Azure DevOps instance.";
 
+    private static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
+    {
+        Description = "The file path corresponding to the Azure DevOps configuration file.",
+        IsRequired = false,
+    };
+
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
         Common.Organization,
         Common.Project,

--- a/src/Valet/Commands/AzureDevOps/BuildPipeline/DryRun.cs
+++ b/src/Valet/Commands/AzureDevOps/BuildPipeline/DryRun.cs
@@ -12,13 +12,8 @@ public class DryRun : ContainerCommand
     protected override string Name => "pipeline";
     protected override string Description => "Target a designer or YAML pipeline";
 
-    public static readonly Option<FileInfo> SourceFilePath = new("--source-file-path")
-    {
-        Description = "The file path corresponding to the Azure DevOps pipeline file.",
-        IsRequired = false,
-    };
-
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
-        SourceFilePath
+        Common.SourceFilePath,
+        Common.PipelineIdNotRequired
     );
 }

--- a/src/Valet/Commands/AzureDevOps/BuildPipeline/DryRun.cs
+++ b/src/Valet/Commands/AzureDevOps/BuildPipeline/DryRun.cs
@@ -19,6 +19,7 @@ public class DryRun : ContainerCommand
     };
 
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        PipelineId,
         Common.SourceFilePath
     );
 }

--- a/src/Valet/Commands/AzureDevOps/BuildPipeline/DryRun.cs
+++ b/src/Valet/Commands/AzureDevOps/BuildPipeline/DryRun.cs
@@ -11,5 +11,14 @@ public class DryRun : ContainerCommand
 
     protected override string Name => "pipeline";
     protected override string Description => "Target a designer or YAML pipeline";
-    protected override ImmutableArray<Option> Options => ImmutableArray<Option>.Empty;
+
+    public static readonly Option<int> PipelineId = new(new[] { "--pipeline-id", "-i" })
+    {
+        Description = "The Azure DevOps pipeline id.",
+        IsRequired = false,
+    };
+
+    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        Common.SourceFilePath
+    );
 }

--- a/src/Valet/Commands/AzureDevOps/BuildPipeline/DryRun.cs
+++ b/src/Valet/Commands/AzureDevOps/BuildPipeline/DryRun.cs
@@ -12,14 +12,13 @@ public class DryRun : ContainerCommand
     protected override string Name => "pipeline";
     protected override string Description => "Target a designer or YAML pipeline";
 
-    public static readonly Option<int> PipelineId = new(new[] { "--pipeline-id", "-i" })
+    public static readonly Option<FileInfo> SourceFilePath = new("--source-file-path")
     {
-        Description = "The Azure DevOps pipeline id.",
+        Description = "The file path corresponding to the Azure DevOps pipeline file.",
         IsRequired = false,
     };
 
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
-        PipelineId,
-        Common.SourceFilePath
+        SourceFilePath
     );
 }

--- a/src/Valet/Commands/AzureDevOps/BuildPipeline/Migrate.cs
+++ b/src/Valet/Commands/AzureDevOps/BuildPipeline/Migrate.cs
@@ -11,5 +11,9 @@ public class Migrate : ContainerCommand
 
     protected override string Name => "pipeline";
     protected override string Description => "Target a designer or YAML pipeline";
-    protected override ImmutableArray<Option> Options => ImmutableArray<Option>.Empty;
+
+    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        Common.SourceFilePath,
+        Common.PipelineIdNotRequired
+    );
 }

--- a/src/Valet/Commands/AzureDevOps/Common.cs
+++ b/src/Valet/Commands/AzureDevOps/Common.cs
@@ -28,6 +28,12 @@ public static class Common
         IsRequired = false,
     };
 
+    public static readonly Option<int> PipelineId = new(new[] { "--pipeline-id", "-i" })
+    {
+        Description = "The Azure DevOps pipeline id.",
+        IsRequired = true,
+    };
+
     public static readonly Option<FileInfo> SourceFilePath = new("--source-file-path")
     {
         Description = "The file path corresponding to the Azure DevOps pipeline file.",

--- a/src/Valet/Commands/AzureDevOps/Common.cs
+++ b/src/Valet/Commands/AzureDevOps/Common.cs
@@ -28,9 +28,21 @@ public static class Common
         IsRequired = false,
     };
 
-    public static readonly Option<int> PipelineId = new(new[] { "--pipeline-id", "-i" })
+    public static readonly Option<int> PipelineIdRequired = new(new[] { "--pipeline-id", "-i" })
     {
         Description = "The Azure DevOps pipeline id.",
         IsRequired = true,
+    };
+
+    public static readonly Option<int> PipelineIdNotRequired = new(new[] { "--pipeline-id", "-i" })
+    {
+        Description = "The Azure DevOps pipeline id.",
+        IsRequired = false,
+    };
+
+    public static readonly Option<FileInfo> SourceFilePath = new("--source-file-path")
+    {
+        Description = "The file path corresponding to the Azure DevOps pipeline file.",
+        IsRequired = false,
     };
 }

--- a/src/Valet/Commands/AzureDevOps/Common.cs
+++ b/src/Valet/Commands/AzureDevOps/Common.cs
@@ -33,10 +33,4 @@ public static class Common
         Description = "The Azure DevOps pipeline id.",
         IsRequired = true,
     };
-
-    public static readonly Option<FileInfo> SourceFilePath = new("--source-file-path")
-    {
-        Description = "The file path corresponding to the Azure DevOps pipeline file.",
-        IsRequired = false,
-    };
 }

--- a/src/Valet/Commands/AzureDevOps/Common.cs
+++ b/src/Valet/Commands/AzureDevOps/Common.cs
@@ -30,13 +30,13 @@ public static class Common
 
     public static readonly Option<int> PipelineIdRequired = new(new[] { "--pipeline-id", "-i" })
     {
-        Description = "The Azure DevOps pipeline id.",
+        Description = "The Azure DevOps pipeline ID.",
         IsRequired = true,
     };
 
     public static readonly Option<int> PipelineIdNotRequired = new(new[] { "--pipeline-id", "-i" })
     {
-        Description = "The Azure DevOps pipeline id.",
+        Description = "The Azure DevOps pipeline ID.",
         IsRequired = false,
     };
 

--- a/src/Valet/Commands/AzureDevOps/Common.cs
+++ b/src/Valet/Commands/AzureDevOps/Common.cs
@@ -28,9 +28,9 @@ public static class Common
         IsRequired = false,
     };
 
-    public static readonly Option<int> PipelineId = new(new[] { "--pipeline-id", "-i" })
+    public static readonly Option<FileInfo> SourceFilePath = new("--source-file-path")
     {
-        Description = "The Azure DevOps pipeline id.",
-        IsRequired = true,
+        Description = "The file path corresponding to the Azure DevOps pipeline file.",
+        IsRequired = false,
     };
 }

--- a/src/Valet/Commands/AzureDevOps/DryRun.cs
+++ b/src/Valet/Commands/AzureDevOps/DryRun.cs
@@ -18,7 +18,6 @@ public class DryRun : BaseCommand
     {
         var command = base.GenerateCommand(app);
 
-        command.AddGlobalOption(Common.PipelineId);
         command.AddGlobalOption(Common.InstanceUrl);
         command.AddGlobalOption(Common.Organization);
         command.AddGlobalOption(Common.Project);

--- a/src/Valet/Commands/AzureDevOps/Migrate.cs
+++ b/src/Valet/Commands/AzureDevOps/Migrate.cs
@@ -18,7 +18,6 @@ public class Migrate : BaseCommand
     {
         var command = base.GenerateCommand(app);
 
-        command.AddGlobalOption(Common.PipelineId);
         command.AddGlobalOption(Common.InstanceUrl);
         command.AddGlobalOption(Common.Organization);
         command.AddGlobalOption(Common.Project);

--- a/src/Valet/Commands/AzureDevOps/ReleasePipeline/DryRun.cs
+++ b/src/Valet/Commands/AzureDevOps/ReleasePipeline/DryRun.cs
@@ -12,11 +12,5 @@ public class DryRun : ContainerCommand
     protected override string Name => "release";
     protected override string Description => "Target a release pipeline";
 
-    public static readonly Option<int> PipelineId = new(new[] { "--pipeline-id", "-i" })
-    {
-        Description = "The Azure DevOps pipeline id.",
-        IsRequired = true,
-    };
-
     protected override ImmutableArray<Option> Options => ImmutableArray<Option>.Empty;
 }

--- a/src/Valet/Commands/AzureDevOps/ReleasePipeline/DryRun.cs
+++ b/src/Valet/Commands/AzureDevOps/ReleasePipeline/DryRun.cs
@@ -11,5 +11,12 @@ public class DryRun : ContainerCommand
 
     protected override string Name => "release";
     protected override string Description => "Target a release pipeline";
+
+    public static readonly Option<int> PipelineId = new(new[] { "--pipeline-id", "-i" })
+    {
+        Description = "The Azure DevOps pipeline id.",
+        IsRequired = true,
+    };
+
     protected override ImmutableArray<Option> Options => ImmutableArray<Option>.Empty;
 }

--- a/src/Valet/Commands/AzureDevOps/ReleasePipeline/DryRun.cs
+++ b/src/Valet/Commands/AzureDevOps/ReleasePipeline/DryRun.cs
@@ -11,6 +11,5 @@ public class DryRun : ContainerCommand
 
     protected override string Name => "release";
     protected override string Description => "Target a release pipeline";
-
     protected override ImmutableArray<Option> Options => ImmutableArray<Option>.Empty;
 }

--- a/src/Valet/Commands/AzureDevOps/ReleasePipeline/DryRun.cs
+++ b/src/Valet/Commands/AzureDevOps/ReleasePipeline/DryRun.cs
@@ -11,5 +11,7 @@ public class DryRun : ContainerCommand
 
     protected override string Name => "release";
     protected override string Description => "Target a release pipeline";
-    protected override ImmutableArray<Option> Options => ImmutableArray<Option>.Empty;
+    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        Common.PipelineIdRequired
+    );
 }

--- a/src/Valet/Commands/AzureDevOps/ReleasePipeline/Migrate.cs
+++ b/src/Valet/Commands/AzureDevOps/ReleasePipeline/Migrate.cs
@@ -11,5 +11,8 @@ public class Migrate : ContainerCommand
 
     protected override string Name => "release";
     protected override string Description => "Target a release pipeline";
-    protected override ImmutableArray<Option> Options => ImmutableArray<Option>.Empty;
+
+    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        Common.PipelineIdRequired
+    );
 }

--- a/src/Valet/Valet.csproj
+++ b/src/Valet/Valet.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Sharprompt" Version="2.4.5" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />


### PR DESCRIPTION
## What's changing?
Make sure you have the latest version of the Valet container: 
`gh valet update`

Build c# project:
`dotnet build /Users/bguereca/1ESLighthouse/gh-valet/gh-valet/src/Valet/Valet.csproj `

Make sure you add a sample ADO pipeline to `output/pipeline.yml`
```
trigger:
- main

pool:
  vmImage: ubuntu-latest

steps:
- script: echo Hello, world!
  displayName: 'Run a one-line script'

- script: |
    echo Add other tasks to build, test, and deploy your project.
    echo See https://aka.ms/yaml
  displayName: 'Run a multi-line script'
```

also `output/config.yaml`:
```
pipelines:
  - project_slug: valet-testing/unit/basic-pipeline-sample
    source_file_path: output/pipeline.yml
  - project_slug: valet-testing/unit/directed-acrylic-graph-pipeline
    source_file_path: output/pipeline.yml

```

Regular commands: 
`dotnet run --project src/Valet/Valet.csproj -- dry-run azure-devops pipeline --pipeline-id 427 -o "output"` 

`dotnet run --project src/Valet/Valet.csproj -- migrate azure-devops pipeline --pipeline-id 427 -o "output" --target-url "https://github.com/begonaguereca/demo"`

`dotnet run --project src/Valet/Valet.csproj -- audit azure-devops -o "output"`
________________________________

Commands with config options:

Run a dry-run with `source-file-path`:
`dotnet run --project src/Valet/Valet.csproj -- dry-run azure-devops pipeline -o "output" --source-file-path output/pipeline.yml`

Run for migrate with `source-file-path`: 
`dotnet run --project src/Valet/Valet.csproj -- migrate azure-devops pipeline -o "output" --source-file-path output/pipeline.yml --target-url "https://github.com/begonaguereca/demo"`

Run for audit with a `config-file-path`: 
`dotnet run --project src/Valet/Valet.csproj -- audit azure-devops -o "output" --config-file-path "output/config.yml" `

## How's this tested?

Closes [related issues]
