### PR TITLE
Added `--config-file-path` option to all migrate and dry run commands 

### DIFF
--- a/src/Valet/Commands/AzureDevOps/Audit.cs
+++ b/src/Valet/Commands/AzureDevOps/Audit.cs
@@ -13,14 +13,8 @@ public class Audit : ContainerCommand
     protected override string Name => "azure-devops";
     protected override string Description => "An audit will output a list of data used in an Azure DevOps instance.";
 
-    private static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
-    {
-        Description = "The file path corresponding to the Azure DevOps configuration file.",
-        IsRequired = false,
-    };
-
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
-        ConfigFilePath,
+        Common.ConfigFilePath,
         Common.Organization,
         Common.Project,
         Common.InstanceUrl,

--- a/src/Valet/Commands/AzureDevOps/BuildPipeline/DryRun.cs
+++ b/src/Valet/Commands/AzureDevOps/BuildPipeline/DryRun.cs
@@ -12,7 +12,7 @@ public class DryRun : ContainerCommand
     protected override string Name => "pipeline";
     protected override string Description => "Target a designer or YAML pipeline";
 
-    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(\
+    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
         Common.ConfigFilePath,
         Common.SourceFilePath,
         Common.PipelineIdNotRequired

--- a/src/Valet/Commands/AzureDevOps/BuildPipeline/DryRun.cs
+++ b/src/Valet/Commands/AzureDevOps/BuildPipeline/DryRun.cs
@@ -12,7 +12,8 @@ public class DryRun : ContainerCommand
     protected override string Name => "pipeline";
     protected override string Description => "Target a designer or YAML pipeline";
 
-    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(\
+        Common.ConfigFilePath,
         Common.SourceFilePath,
         Common.PipelineIdNotRequired
     );

--- a/src/Valet/Commands/AzureDevOps/BuildPipeline/Migrate.cs
+++ b/src/Valet/Commands/AzureDevOps/BuildPipeline/Migrate.cs
@@ -13,6 +13,7 @@ public class Migrate : ContainerCommand
     protected override string Description => "Target a designer or YAML pipeline";
 
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        Common.ConfigFilePath,
         Common.SourceFilePath,
         Common.PipelineIdNotRequired
     );

--- a/src/Valet/Commands/AzureDevOps/Common.cs
+++ b/src/Valet/Commands/AzureDevOps/Common.cs
@@ -45,4 +45,10 @@ public static class Common
         Description = "The file path corresponding to the Azure DevOps pipeline file.",
         IsRequired = false,
     };
+
+    public static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
+    {
+        Description = "The GitHub Actions Importer configuration file.",
+        IsRequired = false,
+    };
 }

--- a/src/Valet/Commands/AzureDevOps/Common.cs
+++ b/src/Valet/Commands/AzureDevOps/Common.cs
@@ -48,7 +48,7 @@ public static class Common
 
     public static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
     {
-        Description = "The GitHub Actions Importer configuration file.",
+        Description = "The file path to the GitHub Actions Importer configuration file.",
         IsRequired = false,
     };
 }

--- a/src/Valet/Commands/AzureDevOps/ReleasePipeline/DryRun.cs
+++ b/src/Valet/Commands/AzureDevOps/ReleasePipeline/DryRun.cs
@@ -12,6 +12,7 @@ public class DryRun : ContainerCommand
     protected override string Name => "release";
     protected override string Description => "Target a release pipeline";
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        Common.ConfigFilePath,
         Common.PipelineIdRequired
     );
 }

--- a/src/Valet/Commands/AzureDevOps/ReleasePipeline/DryRun.cs
+++ b/src/Valet/Commands/AzureDevOps/ReleasePipeline/DryRun.cs
@@ -12,7 +12,6 @@ public class DryRun : ContainerCommand
     protected override string Name => "release";
     protected override string Description => "Target a release pipeline";
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
-        Common.ConfigFilePath,
         Common.PipelineIdRequired
     );
 }

--- a/src/Valet/Commands/Circle/Audit.cs
+++ b/src/Valet/Commands/Circle/Audit.cs
@@ -12,12 +12,6 @@ public class Audit : ContainerCommand
     protected override string Name => "circle-ci";
     protected override string Description => "An audit will output a list of data used in a CircleCI instance.";
 
-    private static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
-    {
-        Description = "The file path corresponding to the CircleCI configuration file.",
-        IsRequired = false,
-    };
-
     private static readonly Option<FileInfo> IncludeFrom = new("--include-from")
     {
         Description = "The file path containing a list of line-delimited repositories to include in the audit.",
@@ -30,7 +24,7 @@ public class Audit : ContainerCommand
         Common.Organization,
         Common.SourceGitHubAccessToken,
         Common.SourceGitHubInstanceUrl,
-        ConfigFilePath,
+        Common.ConfigFilePath,
         IncludeFrom
     );
 }

--- a/src/Valet/Commands/Circle/Common.cs
+++ b/src/Valet/Commands/Circle/Common.cs
@@ -54,7 +54,7 @@ public static class Common
 
     public static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
     {
-        Description = "The GitHub Actions Importer configuration file.",
+        Description = "The file path to the GitHub Actions Importer configuration file.",
         IsRequired = false,
     };
 }

--- a/src/Valet/Commands/Circle/Common.cs
+++ b/src/Valet/Commands/Circle/Common.cs
@@ -51,4 +51,10 @@ public static class Common
         Description = "The file path corresponding to the CircleCI workflow file.",
         IsRequired = false,
     };
+
+    public static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
+    {
+        Description = "The GitHub Actions Importer configuration file.",
+        IsRequired = false,
+    };
 }

--- a/src/Valet/Commands/Circle/DryRun.cs
+++ b/src/Valet/Commands/Circle/DryRun.cs
@@ -20,6 +20,7 @@ public class DryRun : ContainerCommand
         Common.AccessToken,
         Common.SourceGitHubAccessToken,
         Common.SourceGitHubInstanceUrl,
-        Common.SourceFilePath
+        Common.SourceFilePath,
+        Common.ConfigFilePath
     );
 }

--- a/src/Valet/Commands/Circle/Migrate.cs
+++ b/src/Valet/Commands/Circle/Migrate.cs
@@ -20,6 +20,7 @@ public class Migrate : ContainerCommand
         Common.AccessToken,
         Common.SourceGitHubAccessToken,
         Common.SourceGitHubInstanceUrl,
-        Common.SourceFilePath
+        Common.SourceFilePath,
+        Common.ConfigFilePath
     );
 }

--- a/src/Valet/Commands/GitLab/Audit.cs
+++ b/src/Valet/Commands/GitLab/Audit.cs
@@ -12,16 +12,10 @@ public class Audit : ContainerCommand
     protected override string Name => "gitlab";
     protected override string Description => "An audit will output a list of data used in a GitLab instance.";
 
-    private static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
-    {
-        Description = "The file path corresponding to the GitLab configuration file.",
-        IsRequired = false,
-    };
-
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
         Common.InstanceUrl,
         Common.AccessToken,
         Common.Namespace,
-        ConfigFilePath
+        Common.ConfigFilePath
     );
 }

--- a/src/Valet/Commands/GitLab/Common.cs
+++ b/src/Valet/Commands/GitLab/Common.cs
@@ -34,4 +34,10 @@ public static class Common
         Description = "The GitLab project name.",
         IsRequired = true,
     };
+
+    public static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
+    {
+        Description = "The GitHub Actions Importer configuration file.",
+        IsRequired = false,
+    };
 }

--- a/src/Valet/Commands/GitLab/Common.cs
+++ b/src/Valet/Commands/GitLab/Common.cs
@@ -37,7 +37,7 @@ public static class Common
 
     public static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
     {
-        Description = "The GitHub Actions Importer configuration file.",
+        Description = "The file path to the GitHub Actions Importer configuration file.",
         IsRequired = false,
     };
 }

--- a/src/Valet/Commands/GitLab/DryRun.cs
+++ b/src/Valet/Commands/GitLab/DryRun.cs
@@ -17,6 +17,7 @@ public class DryRun : ContainerCommand
         Common.Project,
         Common.InstanceUrl,
         Common.AccessToken,
-        Common.SourceFilePath
+        Common.SourceFilePath,
+        Common.ConfigFilePath
     );
 }

--- a/src/Valet/Commands/GitLab/Migrate.cs
+++ b/src/Valet/Commands/GitLab/Migrate.cs
@@ -17,6 +17,7 @@ public class Migrate : ContainerCommand
         Common.Project,
         Common.InstanceUrl,
         Common.AccessToken,
-        Common.SourceFilePath
+        Common.SourceFilePath,
+        Common.ConfigFilePath
     );
 }

--- a/src/Valet/Commands/Jenkins/Audit.cs
+++ b/src/Valet/Commands/Jenkins/Audit.cs
@@ -12,17 +12,11 @@ public class Audit : ContainerCommand
     protected override string Name => "jenkins";
     protected override string Description => "An audit will output a list of data used in a Jenkins instance.";
 
-    private static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
-    {
-        Description = "The file path corresponding to the Jenkins configuration file.",
-        IsRequired = false,
-    };
-
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
         Common.InstanceUrl,
         Common.Username,
         Common.AccessToken,
         Common.JenkinsfileAccessToken,
-        ConfigFilePath
+        Common.ConfigFilePath
     );
 }

--- a/src/Valet/Commands/Jenkins/Common.cs
+++ b/src/Valet/Commands/Jenkins/Common.cs
@@ -39,4 +39,10 @@ public static class Common
         Description = "The URL of the Jenkins job to migrate.",
         IsRequired = true,
     };
+
+    public static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
+    {
+        Description = "The GitHub Actions Importer configuration file.",
+        IsRequired = false,
+    };
 }

--- a/src/Valet/Commands/Jenkins/Common.cs
+++ b/src/Valet/Commands/Jenkins/Common.cs
@@ -42,7 +42,7 @@ public static class Common
 
     public static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
     {
-        Description = "The GitHub Actions Importer configuration file.",
+        Description = "The file path to the GitHub Actions Importer configuration file.",
         IsRequired = false,
     };
 }

--- a/src/Valet/Commands/Jenkins/DryRun.cs
+++ b/src/Valet/Commands/Jenkins/DryRun.cs
@@ -18,6 +18,7 @@ public class DryRun : ContainerCommand
         Common.Username,
         Common.AccessToken,
         Common.JenkinsfileAccessToken,
-        Common.SourceFilePath
+        Common.SourceFilePath,
+        Common.ConfigFilePath
     );
 }

--- a/src/Valet/Commands/Jenkins/Migrate.cs
+++ b/src/Valet/Commands/Jenkins/Migrate.cs
@@ -18,6 +18,7 @@ public class Migrate : ContainerCommand
         Common.Username,
         Common.AccessToken,
         Common.JenkinsfileAccessToken,
-        Common.SourceFilePath
+        Common.SourceFilePath,
+        Common.ConfigFilePath
     );
 }

--- a/src/Valet/Commands/Travis/Audit.cs
+++ b/src/Valet/Commands/Travis/Audit.cs
@@ -11,12 +11,6 @@ public class Audit : ContainerCommand
 
     protected override string Name => "travis-ci";
     protected override string Description => "An audit will output a list of data used in a Travis CI instance.";
-
-    private static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
-    {
-        Description = "The file path corresponding to the Travis CI configuration file.",
-        IsRequired = false,
-    };
     private static readonly Option<bool> AllowInactiveRepositories = new("--allow-inactive-repositories")
     {
         Description = "Include inactive travis repositories.",
@@ -29,7 +23,7 @@ public class Audit : ContainerCommand
         Common.AccessToken,
         Common.SourceGitHubInstanceUrl,
         Common.SourceGitHubAccessToken,
-        ConfigFilePath,
+        Common.ConfigFilePath,
         AllowInactiveRepositories
     );
 }

--- a/src/Valet/Commands/Travis/Common.cs
+++ b/src/Valet/Commands/Travis/Common.cs
@@ -48,7 +48,7 @@ public static class Common
 
     public static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
     {
-        Description = "The GitHub Actions Importer configuration file.",
+        Description = "The file path to the GitHub Actions Importer configuration file.",
         IsRequired = false,
     };
 }

--- a/src/Valet/Commands/Travis/Common.cs
+++ b/src/Valet/Commands/Travis/Common.cs
@@ -45,4 +45,10 @@ public static class Common
         Description = "The Travis CI repository name.",
         IsRequired = true,
     };
+
+    public static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
+    {
+        Description = "The GitHub Actions Importer configuration file.",
+        IsRequired = false,
+    };
 }

--- a/src/Valet/Commands/Travis/DryRun.cs
+++ b/src/Valet/Commands/Travis/DryRun.cs
@@ -19,6 +19,7 @@ public class DryRun : ContainerCommand
         Common.AccessToken,
         Common.SourceGitHubInstanceUrl,
         Common.SourceGitHubAccessToken,
-        Common.SourceFilePath
+        Common.SourceFilePath,
+        Common.ConfigFilePath
     );
 }

--- a/src/Valet/Commands/Travis/Migrate.cs
+++ b/src/Valet/Commands/Travis/Migrate.cs
@@ -19,6 +19,7 @@ public class Migrate : ContainerCommand
         Common.AccessToken,
         Common.SourceGitHubInstanceUrl,
         Common.SourceGitHubAccessToken,
-        Common.SourceFilePath
+        Common.SourceFilePath,
+        Common.ConfigFilePath
     );
 }


### PR DESCRIPTION
## What's changing?
Adding `--config-file-path` option to all providers. 

Make sure you have the latest version of the Valet container: 
`gh valet update`

Build c# project:
`dotnet build /Users/bguereca/1ESLighthouse/gh-valet/gh-valet/src/Valet/Valet.csproj `
.
.
.
.
.
<details>
    <summary>Azure DevOps commands</summary>

`output/ado/pipeline.yml`
```
trigger:
- main

pool:
  vmImage: ubuntu-latest

steps:
- script: echo Hello, world!
  displayName: 'Run a one-line script'

- script: |
    echo Add other tasks to build, test, and deploy your project.
    echo See https://aka.ms/yaml
  displayName: 'Run a multi-line script'
```

also `output/ado/config.yaml`:
```
source_files:
  - repository_slug: valet-testing/build-playground
    path: output/ado/pipeline.yml
  - repository_slug: valet-testing/unit/directed-acrylic-graph-pipeline
    path: output/ado/pipeline.yml


```
________________________________

🚗 

Run a dry-run with `source-file-path`:
`dotnet run --project src/Valet/Valet.csproj -- dry-run azure-devops pipeline -o "output" --config-file-path output/config.yml`

MIGRATE
`dotnet run --project src/Valet/Valet.csproj -- migrate azure-devops pipeline -o "output" --config-file-path output/config.yml --target-url "https://github.com/begonaguereca/demo"`

AUDIT
`dotnet run --project src/Valet/Valet.csproj -- audit azure-devops -o "output" --config-file-path "output/config.yml" `
</details>


<details>
  <summary>Circle CI commands</summary>
Make sure you add a sample Circle pipeline to `output/circle/pipeline.yml`

```
version: 2.1

orbs:
  ruby: circleci/ruby@1.1.0
  node: circleci/node@2

jobs:
  build:
    docker:
      - image: cimg/ruby:2.7-node
    steps:
      - checkout
      - ruby/install-deps
      # Store bundle cache
      - node/install-packages:
          pkg-manager: yarn
          cache-key: "yarn.lock"
  test:
    parallelism: 3
    docker:
      - image: cimg/ruby:2.7-node
      - image: circleci/postgres:9.5-alpine
        environment:
          POSTGRES_USER: circleci-demo-ruby
          POSTGRES_DB: rails_blog_test
          POSTGRES_PASSWORD: ""
    environment:
      BUNDLE_JOBS: "3"
      BUNDLE_RETRY: "3"
      PGHOST: 127.0.0.1
      PGUSER: circleci-demo-ruby
      PGPASSWORD: ""
      RAILS_ENV: test
    steps:
      - checkout
      - ruby/install-deps
      - node/install-packages:
          pkg-manager: yarn
          cache-key: "yarn.lock"
      - run:
          name: Wait for DB
          command: dockerize -wait tcp://localhost:5432 -timeout 1m
      - run:
          name: Database setup
          command: bundle exec rails db:schema:load --trace
      # Run rspec in parallel
      - ruby/rspec-test
      - ruby/rubocop-check

workflows:
  version: 2
  build_and_test:
    jobs:
      - build
      - test:
          requires:
            - build
```

also `output/config.yaml`:
```
source_files:
  - repository_slug: valet-testing/unit/basic-pipeline-sample
    path: spec/fixtures/source_files/circle_ci/config.yml
  - repository_slug: valet-testing/unit/directed-acrylic-graph-pipeline
    path: spec/fixtures/source_files/circle_ci/config.yml

```
________________________________

🚗 

DRY-RUN
`dotnet run --project src/Valet/Valet.csproj -- dry-run circle-ci  -o "output"  --circle-ci-project "valet-testing/unit/basic-pipeline-sample" --config-file-path output/circle/config.yml`

MIGRATE
`dotnet run --project src/Valet/Valet.csproj -- migrate circle-ci -o "output" --config-file-path output/circle/config.yml ----circle-ci-project "valet-testing/unit/basic-pipeline-sample" target-url "https://github.com/begonaguereca/demo"`

AUDIT
`dotnet run --project src/Valet/Valet.csproj -- audit circle-ci --output-dir tmp/circle_ci/audit --config-file-path output/circle/config.yml`

</details>

<details>
    <summary>Travis commands</summary>

Make sure you add a sample Travis pipeline to `output/travis/pipeline.yml`
```
language: ruby
os: linux
dist: xenial
rvm:
  - 2.5
  - 2.2
gemfile:
  - gemfiles/Gemfile.rails-3.2.x
  - gemfiles/Gemfile.rails-3.0.x
env:
    - ISOLATED: true
    - ISOLATED: false

jobs:
 include:
  - rvm: 2.5
    gemfile: gemfiles/Gemfile.rails-3.2.x
    env: 
      - ISOLATED: false
    script: ./test 1
    before_script: foo
  - stage: first stage
    rvm: 2.2
    gemfile: gemfiles/Gemfile.rails-3.0.x
    env: 
      - ISOLATED: true
  - stage: deploy
    rvm: 2.5
    gemfile: gemfiles/Gemfile.rails-3.2.x
    deploy: 
      provider: npm
  
 allow_failures:
   - rvm: 2.5
 fast_finish: true

script: 
  - 'if [pull_request == false]'
  - 'sh hello world'

before_install: 
  - gem install bundler
before_script: ./test 2

stages: 
  - first stage
  - test
  - name: deploy
    if: branch = master
```

also `output/travis/config.yaml`:
```
source_files:
  - repository_slug: valet-testing-unit/travis-ci-nodejs-example
    path: output/travis/pipeline.yml
  - repository_slug: valet-testing-unit/travis-ci-go-example
    path: output/travis/pipeline.yml

```
________________________________

🚗 

DRY-RUN
`dotnet run --project src/Valet/Valet.csproj -- dry-run travis-ci  -o "output"  --travis-ci-repository travis-ci-nodejs-example --config-file-path output/travis/config.yml`

MIGRATE
`dotnet run --project src/Valet/Valet.csproj -- migrate travis-ci -o "output"  --travis-ci-repository travis-ci-nodejs-example --config-file-path output/travis/config.yml --target-url "https://github.com/begonaguereca/demo"`

AUDIT
`dotnet run --project src/Valet/Valet.csproj --  audit travis-ci  -o "output" --config-file-path output/travis/config.yml`

</details>



<details>
    <summary>Jenkins commands</summary>

`output/jenkins/pipeline.yml`
```
pipeline {
    agent {
        label 'labelName'
        kubernetes {
          inheritFrom "default"
          workspaceVolume dynamicPVC(requestsSize: "20Gi", accessModes: "ReadWriteOnce")
        }
    }

    stages {
        stage('Build') {
            steps {
                echo 'Hello world!'
            }
        }
    }
}
```

`output/jenkins/config.yaml`
```
source_files:
  - repository_slug: begonaguereca/shell
    path: output/jenkins/Jenkinsfile
  - repository_slug: integration-tests/jenkinsfile/jenkinsfile-inline-elephant
    path: output/jenkins/Jenkinsfile
```
________________________________

🚗 

DRY-RUN
`dotnet run --project src/Valet/Valet.csproj -- dry-run jenkins  -o "output"  --config-file-path output/jenkins/config.yml --source-url https://jenkout.westus2.cloudapp.azure.com/job/begonaguereca/job/shell`

MIGRATE
`dotnet run --project src/Valet/Valet.csproj -- migrate jenkins -o "output" --config-file-path output/jenkins/config.yml --target-url "https://github.com/begonaguereca/demo" --source-url https://jenkout.westus2.cloudapp.azure.com/job/begonaguereca/job/shell`

AUDIT
`dotnet run --project src/Valet/Valet.csproj --  audit jenkins -o "output" --config-file-path output/jenkins/config.yml`
</details>

<details>
    <summary>Gitlab commands</summary>

`output/gitlab/pipeline.yml`
```
stages:
  - build
  - test

image: alpine

build_a:
  stage: build
  script:
    - echo "This job builds something."

test_a:
  stage: test
  script:
    - echo "This job tests something. It will only run when all jobs in the"
    - echo "build stage are complete."
```

`output/jenkins/config.yaml`:
```
source_files:
  - repository_slug: valet-testing/basic-pipeline-sample
    path: output/gitlab/pipeline.yml
  - repository_slug: valet-testing/unit/directed-acrylic-graph-pipeline
    path: output/gitlab/pipeline.yml

```
________________________________

🚗 

DRY-RUN
`dotnet run --project src/Valet/Valet.csproj -- dry-run gitlab  -o "output" --namespace valet-testing --project basic-pipeline-sample --config-file-path output/gitlab/config.yml`

MIGRATE
`dotnet run --project src/Valet/Valet.csproj -- migrate gitlab -o "output"  --namespace valet-testing --project basic-pipeline-sample --config-file-path output/gitlab/config.yml --target-url https://github.com/begonaguereca/demo`

AUDIT
`dotnet run --project src/Valet/Valet.csproj --  audit gitlab -o "output" --config-file-path output/gitlab/config.yml`
</details>

## How's this tested?

Closes https://github.com/github/valet/issues/5325
