### PR TITLE
CI: add required permissions for publishing unit test results.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
 
   unit-test:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: dotnet test
         run: dotnet test src/Valet.UnitTests/Valet.UnitTests.csproj --no-build --no-restore --logger "junit;LogFilePath=unit-tests.xml"
       - name: publish test results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: "**/*-tests.xml"


### PR DESCRIPTION
## What's changing?

Adds required permissions for publishing unit test results. 
Docs: https://github.com/EnricoMi/publish-unit-test-result-action#permissions

## How's this tested?

- Green CI checks. 
- There is a comment with the unit test results. 
